### PR TITLE
fix dupeForSmall ct bug

### DIFF
--- a/src/main/java/gregicadditions/recipes/LargeRecipeMap.java
+++ b/src/main/java/gregicadditions/recipes/LargeRecipeMap.java
@@ -1,27 +1,28 @@
 package gregicadditions.recipes;
 
-import crafttweaker.annotations.ZenRegister;
-import gregicadditions.Gregicality;
 import gregicadditions.recipes.crafttweaker.CTLargeRecipeBuilder;
 import gregicadditions.recipes.map.LargeRecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
-import gregtech.api.recipes.crafttweaker.CTRecipeBuilder;
-import net.minecraftforge.fml.common.Optional.Method;
-import stanhebben.zenscript.annotations.ZenClass;
-import stanhebben.zenscript.annotations.ZenMethod;
 
-@ZenClass("mods.gtadditions.recipe.LargeRecipeMap")
-@ZenRegister
+import java.util.ArrayList;
+import java.util.List;
+
 public class LargeRecipeMap extends RecipeMap<LargeRecipeBuilder> {
+
+    private static final List<LargeRecipeMap> LARGE_RECIPE_MAPS = new ArrayList();
 
     public LargeRecipeMap(String unlocalizedName, int minInputs, int maxInputs, int minOutputs, int maxOutputs, int minFluidInputs, int maxFluidInputs, int minFluidOutputs, int maxFluidOutputs, LargeRecipeBuilder defaultRecipe) {
         super(unlocalizedName, minInputs, maxInputs, minOutputs, maxOutputs, minFluidInputs, maxFluidInputs, minFluidOutputs, maxFluidOutputs, defaultRecipe);
+        LARGE_RECIPE_MAPS.add(this);
     }
 
-    @ZenMethod("recipeBuilder")
-    @Method(modid = Gregicality.MODID)
-    public CTRecipeBuilder ctRecipeBuilder() {
+    public CTLargeRecipeBuilder ctLargeRecipeBuilder() {
         return new CTLargeRecipeBuilder(recipeBuilder());
     }
 
+    public static LargeRecipeMap getLargeMapByName(String unlocalizedName) {
+        return (LargeRecipeMap)LARGE_RECIPE_MAPS.stream().filter((map) -> {
+            return map.unlocalizedName.equals(unlocalizedName);
+        }).findFirst().orElse((LargeRecipeMap) null);
+    }
 }

--- a/src/main/java/gregicadditions/recipes/crafttweaker/CTLargeRecipeBuilder.java
+++ b/src/main/java/gregicadditions/recipes/crafttweaker/CTLargeRecipeBuilder.java
@@ -7,26 +7,21 @@ import crafttweaker.api.liquid.ILiquidStack;
 import crafttweaker.api.minecraft.CraftTweakerMC;
 import gregicadditions.recipes.map.LargeRecipeBuilder;
 import gregtech.api.recipes.CountableIngredient;
-import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.crafttweaker.CTRecipeBuilder;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.Ingredient;
-import stanhebben.zenscript.annotations.ZenClass;
-import stanhebben.zenscript.annotations.ZenMethod;
+import stanhebben.zenscript.annotations.*;
 
-import javax.annotation.Nullable;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.stream.Collectors;
 
 @ZenClass("mods.gtadditions.recipe.LargeRecipeBuilder")
 @ZenRegister
-public class CTLargeRecipeBuilder extends CTRecipeBuilder {
+public class CTLargeRecipeBuilder {
 
     private final LargeRecipeBuilder largeRecipeBuilder;
 
 
     public CTLargeRecipeBuilder(LargeRecipeBuilder backingBuilder) {
-        super(backingBuilder);
         this.largeRecipeBuilder = backingBuilder;
     }
 
@@ -36,5 +31,89 @@ public class CTLargeRecipeBuilder extends CTRecipeBuilder {
         return this;
     }
 
+    @ZenMethod
+    public CTLargeRecipeBuilder duration(int duration) {
+        this.largeRecipeBuilder.duration(duration);
+        return this;
+    }
 
+    @ZenMethod
+    public CTLargeRecipeBuilder EUt(int EUt) {
+        this.largeRecipeBuilder.EUt(EUt);
+        return this;
+    }
+
+    @ZenMethod
+    public CTLargeRecipeBuilder hidden() {
+        this.largeRecipeBuilder.hidden();
+        return this;
+    }
+
+    @ZenMethod
+    public CTLargeRecipeBuilder inputs(IIngredient... ingredients) {
+        this.largeRecipeBuilder.inputsIngredients((Collection)Arrays.stream(ingredients).map((s) -> {
+            return new CountableIngredient(new CTRecipeBuilder.CraftTweakerIngredientWrapper(s), s.getAmount());
+        }).collect(Collectors.toList()));
+        return this;
+    }
+
+    @ZenMethod
+    public CTLargeRecipeBuilder notConsumable(IIngredient ingredient) {
+        this.largeRecipeBuilder.notConsumable(new CTRecipeBuilder.CraftTweakerIngredientWrapper(ingredient));
+        return this;
+    }
+
+    @ZenMethod
+    public CTLargeRecipeBuilder fluidInputs(ILiquidStack... ingredients) {
+        this.largeRecipeBuilder.fluidInputs((Collection)Arrays.stream(ingredients).map(CraftTweakerMC::getLiquidStack).collect(Collectors.toList()));
+        return this;
+    }
+
+    @ZenMethod
+    public CTLargeRecipeBuilder outputs(IItemStack... ingredients) {
+        this.largeRecipeBuilder.outputs((Collection)Arrays.stream(ingredients).map(CraftTweakerMC::getItemStack).collect(Collectors.toList()));
+        return this;
+    }
+
+    @ZenMethod
+    public CTLargeRecipeBuilder chancedOutput(IItemStack outputStack, int chanceValue, int tierChanceBoost) {
+        this.largeRecipeBuilder.chancedOutput(CraftTweakerMC.getItemStack(outputStack), chanceValue, tierChanceBoost);
+        return this;
+    }
+
+    @ZenMethod
+    public CTLargeRecipeBuilder fluidOutputs(ILiquidStack... ingredients) {
+        this.largeRecipeBuilder.fluidOutputs((Collection)Arrays.stream(ingredients).map(CraftTweakerMC::getLiquidStack).collect(Collectors.toList()));
+        return this;
+    }
+
+    @ZenMethod
+    public CTLargeRecipeBuilder property(String key, int value) {
+        boolean applied = this.largeRecipeBuilder.applyProperty(key, value);
+        if (!applied) {
+            throw new IllegalArgumentException("Property " + key + " cannot be applied to recipe type " + this.largeRecipeBuilder.getClass().getSimpleName());
+        } else {
+            return this;
+        }
+    }
+
+    @ZenMethod
+    public CTLargeRecipeBuilder property(String key, IItemStack item) {
+        boolean applied = this.largeRecipeBuilder.applyProperty(key, CraftTweakerMC.getItemStack(item));
+        if (!applied) {
+            throw new IllegalArgumentException("Property " + key + " cannot be applied to recipe type " + this.largeRecipeBuilder.getClass().getSimpleName() + " for Item " + CraftTweakerMC.getItemStack(item).getDisplayName());
+        } else {
+            return this;
+        }
+    }
+
+    @ZenMethod
+    public void buildAndRegister() {
+        this.largeRecipeBuilder.buildAndRegister();
+    }
+
+    @ZenMethod
+    public String toString() {
+        return this.largeRecipeBuilder.toString();
+    }
 }

--- a/src/main/java/gregicadditions/recipes/crafttweaker/CTLargeRecipeMap.java
+++ b/src/main/java/gregicadditions/recipes/crafttweaker/CTLargeRecipeMap.java
@@ -1,0 +1,31 @@
+package gregicadditions.recipes.crafttweaker;
+
+import crafttweaker.annotations.ZenRegister;
+import gregicadditions.Gregicality;
+import gregicadditions.recipes.LargeRecipeMap;
+import net.minecraftforge.fml.common.Optional;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+@ZenClass("mods.gtadditions.recipe.LargeRecipeMap")
+@ZenRegister
+public class CTLargeRecipeMap {
+
+    private LargeRecipeMap largeRecipeMap;
+
+    CTLargeRecipeMap(LargeRecipeMap largeRecipeMap) {
+        this.largeRecipeMap = largeRecipeMap;
+    }
+
+    @ZenMethod("recipeBuilder")
+    @Optional.Method(modid = Gregicality.MODID)
+    public CTLargeRecipeBuilder ctLargeRecipeBuilder() {
+        return largeRecipeMap.ctLargeRecipeBuilder();
+    }
+
+    @ZenMethod("getByName")
+    public static CTLargeRecipeMap ctGetByName(String unlocalizedName) {
+        return new CTLargeRecipeMap(LargeRecipeMap.getLargeMapByName(unlocalizedName));
+    }
+
+}


### PR DESCRIPTION
This looked like a bug i might be able to fix. It took around 6 hours to find a solution, but I'm happy with the result. Here's a working script:
`import mods.gtadditions.recipe.LargeRecipeMap;`
`val large_mixer as LargeRecipeMap = LargeRecipeMap.getByName("large_mixer");`
`   large_mixer.recipeBuilder()`
`   .inputs([<minecraft:iron_ingot> * 2, <ore:ingotGold>])`
`   .outputs([<minecraft:dirt> * 2])`
`   .EUt(120).duration(100)`
`   .dupeForSmall()`
`   .buildAndRegister();`