### PR TITLE
Add RecipeMap cast to CTLargeRecipeMap

### DIFF
--- a/src/main/java/gregicadditions/recipes/crafttweaker/CTLargeRecipeMap.java
+++ b/src/main/java/gregicadditions/recipes/crafttweaker/CTLargeRecipeMap.java
@@ -26,6 +26,12 @@ public class CTLargeRecipeMap {
         this.largeRecipeMap = largeRecipeMap;
     }
 
+    @ZenCaster
+    @ZenMethod
+    public RecipeMap<LargeRecipeBuilder> asRecipeMap() {
+        return this.largeRecipeMap;
+    }
+
     @ZenMethod("recipeBuilder")
     @Optional.Method(modid = Gregicality.MODID)
     public CTLargeRecipeBuilder ctLargeRecipeBuilder() {

--- a/src/main/java/gregicadditions/recipes/crafttweaker/CTLargeRecipeMap.java
+++ b/src/main/java/gregicadditions/recipes/crafttweaker/CTLargeRecipeMap.java
@@ -5,13 +5,14 @@ import crafttweaker.api.item.IItemStack;
 import crafttweaker.api.liquid.ILiquidStack;
 import gregicadditions.Gregicality;
 import gregicadditions.recipes.LargeRecipeMap;
+import gregicadditions.recipes.map.LargeRecipeBuilder;
+import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.crafttweaker.CTRecipe;
 import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import stanhebben.zenscript.annotations.ZenClass;
-import stanhebben.zenscript.annotations.ZenGetter;
-import stanhebben.zenscript.annotations.ZenMethod;
+import stanhebben.zenscript.annotations.*;
+
 
 import javax.annotation.Nullable;
 import java.util.List;


### PR DESCRIPTION
Why? Because removeByOutput needs a RecipeMap. With this cast it works fine.