### PR TITLE
OC API Supplement

### DIFF
--- a/src/main/java/gregicadditions/integrations/opencomputers/OpenComputersCommonProxy.java
+++ b/src/main/java/gregicadditions/integrations/opencomputers/OpenComputersCommonProxy.java
@@ -3,6 +3,7 @@ package gregicadditions.integrations.opencomputers;
 import gregicadditions.GAConfig;
 import gregicadditions.Gregicality;
 import gregicadditions.integrations.opencomputers.driver.*;
+import gregicadditions.integrations.opencomputers.driver.multi.*;
 import li.cil.oc.api.Driver;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
@@ -23,5 +24,11 @@ public class OpenComputersCommonProxy {
         Driver.add(new DriverMultiblockRecipeLogic());
         Driver.add(new DriverICoverable());
         Driver.add(new DriverSimpleMachineMetaTileEntity());
+        Driver.add(new DriverMTENuclearReactor());
+        Driver.add(new DriverMTEVoidMiner());
+        Driver.add(new DriverTEFusionReactor());
+        Driver.add(new DriverTEWorldAccelerator());
+        Driver.add(new DriverQubitMultiblockController());
+        Driver.add(new DriverMTEBatteryTower());
     }
 }

--- a/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverMTEBatteryTower.java
+++ b/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverMTEBatteryTower.java
@@ -1,0 +1,63 @@
+package gregicadditions.integrations.opencomputers.driver.multi;
+
+import gregicadditions.integrations.opencomputers.driver.environment.EnvironmentMetaTileEntity;
+import gregicadditions.machines.multi.MetaTileEntityBatteryTower;
+import gregicadditions.machines.multi.miner.MetaTileEntityVoidMiner;
+import gregtech.api.metatileentity.MetaTileEntityHolder;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.ManagedEnvironment;
+import li.cil.oc.api.prefab.DriverSidedTileEntity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+
+public class DriverMTEBatteryTower extends DriverSidedTileEntity {
+    @Override
+    public Class<?> getTileEntityClass() {
+        return MetaTileEntityBatteryTower.class;
+    }
+
+    @Override
+    public boolean worksWith(World world, BlockPos pos, EnumFacing side) {
+        TileEntity tileEntity = world.getTileEntity(pos);
+        if (tileEntity instanceof MetaTileEntityHolder) {
+            return ((MetaTileEntityHolder) tileEntity).getMetaTileEntity() instanceof MetaTileEntityBatteryTower;
+        }
+        return false;
+    }
+
+    @Override
+    public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side) {
+        TileEntity tileEntity = world.getTileEntity(pos);
+        if (tileEntity instanceof MetaTileEntityHolder) {
+            return new EnvironmentMetaTileEntityBatteryTower((MetaTileEntityHolder) tileEntity,
+                    (MetaTileEntityBatteryTower) ((MetaTileEntityHolder) tileEntity).getMetaTileEntity()
+            );
+        }
+        return null;
+    }
+
+    public final static class EnvironmentMetaTileEntityBatteryTower extends
+            EnvironmentMetaTileEntity<MetaTileEntityBatteryTower> {
+
+        public EnvironmentMetaTileEntityBatteryTower(MetaTileEntityHolder holder, MetaTileEntityBatteryTower tileEntity) {
+            super(holder, tileEntity, "gtce_metaTileEntityBatteryTower");
+        }
+
+        @Callback(doc = "function():boolean --  Returns the energy input per tick of machine.")
+        public Object[] getEnergyInputPerTick(final Context context, final Arguments args) {
+            return new Object[] {tileEntity.getEnergyInputPerTick()};
+        }
+
+        @Callback(doc = "function():number --  Returns the energy output per tick of machine.")
+        public Object[] getEnergyOutputPerTick(final Context context, final Arguments args) {
+            return new Object[] {tileEntity.getEnergyOutputPerTick()};
+        }
+
+
+    }
+}

--- a/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverMTENuclearReactor.java
+++ b/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverMTENuclearReactor.java
@@ -62,12 +62,12 @@ public class DriverMTENuclearReactor extends DriverSidedTileEntity {
 
         @Callback(doc = "function():number --  Returns the recipe base heat of machine.")
         public Object[] getRecipeBaseHeat(final Context context, final Arguments args) {
-            return new Object[] {ObfuscationReflectionHelper.getPrivateValue(MetaTileEntityNuclearReactor.class, tileEntity,"recipeBaseHeat")};
+            return new Object[] {tileEntity.getRecipeBaseHeat()};
         }
 
         @Callback(doc = "function():number --  Returns the rod additional temperature of machine.")
         public Object[] getRodAdditionalTemperature(final Context context, final Arguments args) {
-            return new Object[] {ObfuscationReflectionHelper.getPrivateValue(MetaTileEntityNuclearReactor.class, tileEntity,"rodAdditionalTemperature")};
+            return new Object[] {tileEntity.getRodAdditionalTemperature()};
         }
 
     }

--- a/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverMTENuclearReactor.java
+++ b/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverMTENuclearReactor.java
@@ -1,0 +1,74 @@
+package gregicadditions.integrations.opencomputers.driver.multi;
+
+import gregicadditions.integrations.opencomputers.driver.DriverSimpleMachineMetaTileEntity;
+import gregicadditions.integrations.opencomputers.driver.environment.EnvironmentMetaTileEntity;
+import gregicadditions.machines.multi.nuclear.MetaTileEntityNuclearReactor;
+import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.SimpleMachineMetaTileEntity;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.ManagedEnvironment;
+import li.cil.oc.api.prefab.DriverSidedTileEntity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import net.minecraftforge.fml.relauncher.ReflectionHelper;
+
+public class DriverMTENuclearReactor extends DriverSidedTileEntity {
+    @Override
+    public Class<?> getTileEntityClass() {
+        return MetaTileEntityNuclearReactor.class;
+    }
+
+    @Override
+    public boolean worksWith(World world, BlockPos pos, EnumFacing side) {
+        TileEntity tileEntity = world.getTileEntity(pos);
+        if (tileEntity instanceof MetaTileEntityHolder) {
+            return ((MetaTileEntityHolder) tileEntity).getMetaTileEntity() instanceof MetaTileEntityNuclearReactor;
+        }
+        return false;
+    }
+
+    @Override
+    public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side) {
+        TileEntity tileEntity = world.getTileEntity(pos);
+        if (tileEntity instanceof MetaTileEntityHolder) {
+            return new EnvironmentMetaTileEntityNuclearReactor((MetaTileEntityHolder) tileEntity,
+                    (MetaTileEntityNuclearReactor) ((MetaTileEntityHolder) tileEntity).getMetaTileEntity()
+            );
+        }
+        return null;
+    }
+
+    public final static class EnvironmentMetaTileEntityNuclearReactor extends
+            EnvironmentMetaTileEntity<MetaTileEntityNuclearReactor> {
+
+        public EnvironmentMetaTileEntityNuclearReactor(MetaTileEntityHolder holder, MetaTileEntityNuclearReactor tileEntity) {
+            super(holder, tileEntity, "gtce_metaTileEntityNuclearReactor");
+        }
+
+        @Callback(doc = "function():number --  Returns the coolant needed of machine.")
+        public Object[] getCoolantNeeded(final Context context, final Arguments args) {
+            return new Object[] {tileEntity.coolantNeeded()};
+        }
+
+        @Callback(doc = "function():number --  Returns the coolant ratio of machine.")
+        public Object[] getCoolantRatio(final Context context, final Arguments args) {
+            return new Object[] {tileEntity.coolantRatio()};
+        }
+
+        @Callback(doc = "function():number --  Returns the recipe base heat of machine.")
+        public Object[] getRecipeBaseHeat(final Context context, final Arguments args) {
+            return new Object[] {ObfuscationReflectionHelper.getPrivateValue(MetaTileEntityNuclearReactor.class, tileEntity,"recipeBaseHeat")};
+        }
+
+        @Callback(doc = "function():number --  Returns the rod additional temperature of machine.")
+        public Object[] getRodAdditionalTemperature(final Context context, final Arguments args) {
+            return new Object[] {ObfuscationReflectionHelper.getPrivateValue(MetaTileEntityNuclearReactor.class, tileEntity,"rodAdditionalTemperature")};
+        }
+
+    }
+}

--- a/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverMTEVoidMiner.java
+++ b/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverMTEVoidMiner.java
@@ -1,0 +1,66 @@
+package gregicadditions.integrations.opencomputers.driver.multi;
+
+import gregicadditions.integrations.opencomputers.driver.environment.EnvironmentMetaTileEntity;
+import gregicadditions.machines.multi.miner.MetaTileEntityVoidMiner;
+import gregtech.api.metatileentity.MetaTileEntityHolder;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.ManagedEnvironment;
+import li.cil.oc.api.prefab.DriverSidedTileEntity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+
+public class DriverMTEVoidMiner extends DriverSidedTileEntity {
+    @Override
+    public Class<?> getTileEntityClass() {
+        return MetaTileEntityVoidMiner.class;
+    }
+
+    @Override
+    public boolean worksWith(World world, BlockPos pos, EnumFacing side) {
+        TileEntity tileEntity = world.getTileEntity(pos);
+        if (tileEntity instanceof MetaTileEntityHolder) {
+            return ((MetaTileEntityHolder) tileEntity).getMetaTileEntity() instanceof MetaTileEntityVoidMiner;
+        }
+        return false;
+    }
+
+    @Override
+    public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side) {
+        TileEntity tileEntity = world.getTileEntity(pos);
+        if (tileEntity instanceof MetaTileEntityHolder) {
+            return new EnvironmentMetaTileEntityVoidMiner((MetaTileEntityHolder) tileEntity,
+                    (MetaTileEntityVoidMiner) ((MetaTileEntityHolder) tileEntity).getMetaTileEntity()
+            );
+        }
+        return null;
+    }
+
+    public final static class EnvironmentMetaTileEntityVoidMiner extends
+            EnvironmentMetaTileEntity<MetaTileEntityVoidMiner> {
+
+        public EnvironmentMetaTileEntityVoidMiner(MetaTileEntityHolder holder, MetaTileEntityVoidMiner tileEntity) {
+            super(holder, tileEntity, "gtce_metaTileEntityVoidMiner");
+        }
+
+        @Callback(doc = "function():boolean --  Returns is over heat.")
+        public Object[] isOverHeat(final Context context, final Arguments args) {
+            return new Object[] {ObfuscationReflectionHelper.getPrivateValue(MetaTileEntityVoidMiner.class, tileEntity,"overheat")};
+        }
+
+        @Callback(doc = "function():number --  Returns the temperature of machine.")
+        public Object[] getTemperature(final Context context, final Arguments args) {
+            return new Object[] {ObfuscationReflectionHelper.getPrivateValue(MetaTileEntityVoidMiner.class, tileEntity,"temperature")};
+        }
+
+        @Callback(doc = "function():number --  Returns the max temperature of machine.")
+        public Object[] getMaxTemperature(final Context context, final Arguments args) {
+            return new Object[] {ObfuscationReflectionHelper.getPrivateValue(MetaTileEntityVoidMiner.class, tileEntity,"maxTemperature")};
+        }
+
+    }
+}

--- a/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverMTEVoidMiner.java
+++ b/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverMTEVoidMiner.java
@@ -49,17 +49,22 @@ public class DriverMTEVoidMiner extends DriverSidedTileEntity {
 
         @Callback(doc = "function():boolean --  Returns is over heat.")
         public Object[] isOverHeat(final Context context, final Arguments args) {
-            return new Object[] {ObfuscationReflectionHelper.getPrivateValue(MetaTileEntityVoidMiner.class, tileEntity,"overheat")};
+            return new Object[] {tileEntity.isOverheat()};
         }
 
         @Callback(doc = "function():number --  Returns the temperature of machine.")
         public Object[] getTemperature(final Context context, final Arguments args) {
-            return new Object[] {ObfuscationReflectionHelper.getPrivateValue(MetaTileEntityVoidMiner.class, tileEntity,"temperature")};
+            return new Object[] {tileEntity.getTemperature()};
         }
 
         @Callback(doc = "function():number --  Returns the max temperature of machine.")
         public Object[] getMaxTemperature(final Context context, final Arguments args) {
-            return new Object[] {ObfuscationReflectionHelper.getPrivateValue(MetaTileEntityVoidMiner.class, tileEntity,"maxTemperature")};
+            return new Object[] {tileEntity.getMaxTemperature()};
+        }
+
+        @Callback(doc = "function():number --  Returns the drilling fluid amount of machine.")
+        public Object[] getDrillingFluidAmount(final Context context, final Arguments args) {
+            return new Object[] {tileEntity.getCurrentDrillingFluid()};
         }
 
     }

--- a/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverMultiblockRecipeLogic.java
+++ b/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverMultiblockRecipeLogic.java
@@ -1,4 +1,4 @@
-package gregicadditions.integrations.opencomputers.driver;
+package gregicadditions.integrations.opencomputers.driver.multi;
 
 import gregicadditions.integrations.opencomputers.driver.environment.EnvironmentMetaTileEntity;
 import gregtech.api.capability.GregtechTileCapabilities;

--- a/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverQubitMultiblockController.java
+++ b/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverQubitMultiblockController.java
@@ -1,0 +1,71 @@
+package gregicadditions.integrations.opencomputers.driver.multi;
+
+import gregicadditions.integrations.opencomputers.driver.environment.EnvironmentMetaTileEntity;
+import gregicadditions.machines.multi.nuclear.MetaTileEntityNuclearReactor;
+import gregicadditions.machines.multi.qubit.QubitRecipeMapMultiblockController;
+import gregtech.api.metatileentity.MetaTileEntityHolder;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.ManagedEnvironment;
+import li.cil.oc.api.prefab.DriverSidedTileEntity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DriverQubitMultiblockController extends DriverSidedTileEntity {
+    @Override
+    public Class<?> getTileEntityClass() {
+        return QubitRecipeMapMultiblockController.class;
+    }
+
+    @Override
+    public boolean worksWith(World world, BlockPos pos, EnumFacing side) {
+        TileEntity tileEntity = world.getTileEntity(pos);
+        if (tileEntity instanceof MetaTileEntityHolder) {
+            return ((MetaTileEntityHolder) tileEntity).getMetaTileEntity() instanceof QubitRecipeMapMultiblockController;
+        }
+        return false;
+    }
+
+    @Override
+    public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side) {
+        TileEntity tileEntity = world.getTileEntity(pos);
+        if (tileEntity instanceof MetaTileEntityHolder) {
+            return new EnvironmentQubitRecipeMapMultiblockController((MetaTileEntityHolder) tileEntity,
+                    (QubitRecipeMapMultiblockController) ((MetaTileEntityHolder) tileEntity).getMetaTileEntity()
+            );
+        }
+        return null;
+    }
+
+    public final static class EnvironmentQubitRecipeMapMultiblockController extends
+            EnvironmentMetaTileEntity<QubitRecipeMapMultiblockController> {
+
+        public EnvironmentQubitRecipeMapMultiblockController(MetaTileEntityHolder holder, QubitRecipeMapMultiblockController tileEntity) {
+            super(holder, tileEntity, "gtce_qubitRecipeMapMultiblockController");
+        }
+
+        @Callback(doc = "function():number --  Returns the input Qubit of machine.")
+        public Object[] getInputQubitContainer(final Context context, final Arguments args) {
+            Map<String, Object> map = new HashMap<>();
+            map.put("stored", tileEntity.getInputQubitContainer().getQubitStored());
+            map.put("capacity", tileEntity.getInputQubitContainer().getQubitCapacity());
+            return new Object[] {map};
+        }
+
+        @Callback(doc = "function():number --  Returns the output Qubit of machine.")
+        public Object[] getOutputQubitContainer(final Context context, final Arguments args) {
+            Map<String, Object> map = new HashMap<>();
+            map.put("stored", tileEntity.getOutputQubitContainer().getQubitStored());
+            map.put("capacity", tileEntity.getOutputQubitContainer().getQubitCapacity());
+            return new Object[] {map};
+        }
+
+    }
+}

--- a/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverTEFusionReactor.java
+++ b/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverTEFusionReactor.java
@@ -1,0 +1,58 @@
+package gregicadditions.integrations.opencomputers.driver.multi;
+
+import gregicadditions.integrations.opencomputers.driver.environment.EnvironmentMetaTileEntity;
+import gregicadditions.machines.multi.MetaTileEntityChemicalPlant;
+import gregicadditions.machines.multi.TileEntityFusionReactor;
+import gregicadditions.machines.multi.nuclear.MetaTileEntityNuclearReactor;
+import gregtech.api.metatileentity.MetaTileEntityHolder;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.ManagedEnvironment;
+import li.cil.oc.api.prefab.DriverSidedTileEntity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+
+public class DriverTEFusionReactor extends DriverSidedTileEntity {
+    @Override
+    public Class<?> getTileEntityClass() {
+        return TileEntityFusionReactor.class;
+    }
+
+    @Override
+    public boolean worksWith(World world, BlockPos pos, EnumFacing side) {
+        TileEntity tileEntity = world.getTileEntity(pos);
+        if (tileEntity instanceof MetaTileEntityHolder) {
+            return ((MetaTileEntityHolder) tileEntity).getMetaTileEntity() instanceof TileEntityFusionReactor;
+        }
+        return false;
+    }
+
+    @Override
+    public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side) {
+        TileEntity tileEntity = world.getTileEntity(pos);
+        if (tileEntity instanceof MetaTileEntityHolder) {
+            return new EnvironmentTileEntityFusionReactor((MetaTileEntityHolder) tileEntity,
+                    (TileEntityFusionReactor) ((MetaTileEntityHolder) tileEntity).getMetaTileEntity()
+            );
+        }
+        return null;
+    }
+
+    public final static class EnvironmentTileEntityFusionReactor extends
+            EnvironmentMetaTileEntity<TileEntityFusionReactor> {
+
+        public EnvironmentTileEntityFusionReactor(MetaTileEntityHolder holder, TileEntityFusionReactor tileEntity) {
+            super(holder, tileEntity, "gtce_tileEntityFusionReactor");
+        }
+
+        @Callback(doc = "function():number --  Returns the heat of machine.")
+        public Object[] getHeat(final Context context, final Arguments args) {
+            return new Object[] {ObfuscationReflectionHelper.getPrivateValue(TileEntityFusionReactor.class, tileEntity,"heat")};
+        }
+
+    }
+}

--- a/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverTEFusionReactor.java
+++ b/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverTEFusionReactor.java
@@ -51,7 +51,7 @@ public class DriverTEFusionReactor extends DriverSidedTileEntity {
 
         @Callback(doc = "function():number --  Returns the heat of machine.")
         public Object[] getHeat(final Context context, final Arguments args) {
-            return new Object[] {ObfuscationReflectionHelper.getPrivateValue(TileEntityFusionReactor.class, tileEntity,"heat")};
+            return new Object[] {tileEntity.getHeat()};
         }
 
     }

--- a/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverTEWorldAccelerator.java
+++ b/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverTEWorldAccelerator.java
@@ -1,0 +1,76 @@
+package gregicadditions.integrations.opencomputers.driver.multi;
+
+import gregicadditions.integrations.opencomputers.driver.environment.EnvironmentMetaTileEntity;
+import gregicadditions.machines.TileEntityWorldAccelerator;
+import gregicadditions.machines.multi.TileEntityFusionReactor;
+import gregtech.api.metatileentity.MetaTileEntityHolder;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.ManagedEnvironment;
+import li.cil.oc.api.prefab.DriverSidedTileEntity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+
+public class DriverTEWorldAccelerator extends DriverSidedTileEntity {
+    @Override
+    public Class<?> getTileEntityClass() {
+        return TileEntityWorldAccelerator.class;
+    }
+
+    @Override
+    public boolean worksWith(World world, BlockPos pos, EnumFacing side) {
+        TileEntity tileEntity = world.getTileEntity(pos);
+        if (tileEntity instanceof MetaTileEntityHolder) {
+            return ((MetaTileEntityHolder) tileEntity).getMetaTileEntity() instanceof TileEntityWorldAccelerator;
+        }
+        return false;
+    }
+
+    @Override
+    public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side) {
+        TileEntity tileEntity = world.getTileEntity(pos);
+        if (tileEntity instanceof MetaTileEntityHolder) {
+            return new EnvironmentTileEntityWorldAccelerator((MetaTileEntityHolder) tileEntity,
+                    (TileEntityWorldAccelerator) ((MetaTileEntityHolder) tileEntity).getMetaTileEntity()
+            );
+        }
+        return null;
+    }
+
+    public final static class EnvironmentTileEntityWorldAccelerator extends
+            EnvironmentMetaTileEntity<TileEntityWorldAccelerator> {
+
+        public EnvironmentTileEntityWorldAccelerator(MetaTileEntityHolder holder, TileEntityWorldAccelerator tileEntity) {
+            super(holder, tileEntity, "gtce_tileEntityWorldAccelerator");
+        }
+
+        @Callback(doc = "function():number --  Returns the tile mode of machine.")
+        public Object[] getTileMode(final Context context, final Arguments args) {
+            return new Object[] {ObfuscationReflectionHelper.getPrivateValue(TileEntityWorldAccelerator.class, tileEntity,"tileMode")};
+        }
+
+        @Callback(doc = "function(isTile:boolean) --  Sets the tile mode of machine.")
+        public Object[] setTileMode(final Context context, final Arguments args) {
+            ObfuscationReflectionHelper.setPrivateValue(TileEntityWorldAccelerator.class, tileEntity, args.checkBoolean(0),"tileMode");
+            return new Object[] {};
+        }
+
+        @Callback(doc = "function():boolean --  Returns is working enabled.")
+        public Object[] isWorkingEnabled(final Context context, final Arguments args) {
+            return new Object[] {tileEntity.isWorkingEnabled()};
+        }
+
+        @Callback(doc = "function(workingEnabled:boolean):boolean -- "
+                + "Sets working enabled, return last working enabled.")
+        public Object[] setWorkingEnabled(final Context context, final Arguments args) {
+            boolean lsatState = tileEntity.isWorkingEnabled();
+            tileEntity.setWorkingEnabled(args.checkBoolean(0));
+            return new Object[] {lsatState};
+        }
+
+    }
+}

--- a/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverTEWorldAccelerator.java
+++ b/src/main/java/gregicadditions/integrations/opencomputers/driver/multi/DriverTEWorldAccelerator.java
@@ -48,14 +48,14 @@ public class DriverTEWorldAccelerator extends DriverSidedTileEntity {
             super(holder, tileEntity, "gtce_tileEntityWorldAccelerator");
         }
 
-        @Callback(doc = "function():number --  Returns the tile mode of machine.")
-        public Object[] getTileMode(final Context context, final Arguments args) {
-            return new Object[] {ObfuscationReflectionHelper.getPrivateValue(TileEntityWorldAccelerator.class, tileEntity,"tileMode")};
+        @Callback(doc = "function():boolean --  Returns the mode of machine.")
+        public Object[] isTileMode(final Context context, final Arguments args) {
+            return new Object[] {tileEntity.isTileMode()};
         }
 
-        @Callback(doc = "function(isTile:boolean) --  Sets the tile mode of machine.")
+        @Callback(doc = "function(isTile:boolean) --  Sets the mode of machine.")
         public Object[] setTileMode(final Context context, final Arguments args) {
-            ObfuscationReflectionHelper.setPrivateValue(TileEntityWorldAccelerator.class, tileEntity, args.checkBoolean(0),"tileMode");
+            tileEntity.setTileMode(args.checkBoolean(0));
             return new Object[] {};
         }
 

--- a/src/main/java/gregicadditions/machines/TileEntityWorldAccelerator.java
+++ b/src/main/java/gregicadditions/machines/TileEntityWorldAccelerator.java
@@ -226,4 +226,12 @@ public class TileEntityWorldAccelerator extends GATieredMetaTileEntity implement
         }
         return super.getCapability(capability, side);
     }
+
+    public boolean isTileMode() {
+        return tileMode;
+    }
+
+    public void setTileMode(boolean tileMode) {
+        this.tileMode = tileMode;
+    }
 }

--- a/src/main/java/gregicadditions/machines/multi/MetaTileEntityBatteryTower.java
+++ b/src/main/java/gregicadditions/machines/multi/MetaTileEntityBatteryTower.java
@@ -53,6 +53,8 @@ public class MetaTileEntityBatteryTower extends MultiblockWithDisplayBase implem
     private EnergyContainerList input;
     private EnergyContainerList output;
     private CellCasing.CellType cell;
+    private long energyInputPerTick;
+    private long energyOutputPerTick;
 
     public MetaTileEntityBatteryTower(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId);
@@ -86,6 +88,8 @@ public class MetaTileEntityBatteryTower extends MultiblockWithDisplayBase implem
         output = new EnergyContainerList(getAbilities(MultiblockAbility.OUTPUT_ENERGY));
         BigInteger capacity = BigInteger.valueOf(this.cell.getStorage()).multiply(BigInteger.valueOf(size));
         maxCapacity =  capacity.min(BigInteger.valueOf(Long.MAX_VALUE)).longValue();
+        energyInputPerTick = 0;
+        energyOutputPerTick = 0;
 
     }
 
@@ -103,13 +107,13 @@ public class MetaTileEntityBatteryTower extends MultiblockWithDisplayBase implem
         if (!getWorld().isRemote) {
             long inputEnergyStore = input.getEnergyStored();
             long energyAddedFromInput = this.addEnergy(inputEnergyStore);
-            input.changeEnergy(-energyAddedFromInput);
+            energyInputPerTick = input.changeEnergy(-energyAddedFromInput);
 
             this.changeEnergy(-GAValues.V[cell.getTier()] * 10 / 100);
 
             long bankEnergyStore = this.getEnergyStored();
             long energyAddedFromBank = output.addEnergy(bankEnergyStore);
-            this.changeEnergy(-energyAddedFromBank);
+            energyOutputPerTick = this.changeEnergy(-energyAddedFromBank);
         }
     }
 
@@ -234,6 +238,14 @@ public class MetaTileEntityBatteryTower extends MultiblockWithDisplayBase implem
         }
         this.setEnergyStored(newEnergyStored);
         return newEnergyStored - oldEnergyStored;
+    }
+
+    public long getEnergyInputPerTick() {
+        return energyInputPerTick;
+    }
+
+    public long getEnergyOutputPerTick() {
+        return energyOutputPerTick;
     }
 
     @Override

--- a/src/main/java/gregicadditions/machines/multi/TileEntityFusionReactor.java
+++ b/src/main/java/gregicadditions/machines/multi/TileEntityFusionReactor.java
@@ -243,4 +243,8 @@ public class TileEntityFusionReactor extends RecipeMapMultiblockController {
             heat = compound.getInteger("Heat");
         }
     }
+
+    public int getHeat() {
+        return heat;
+    }
 }

--- a/src/main/java/gregicadditions/machines/multi/miner/MetaTileEntityVoidMiner.java
+++ b/src/main/java/gregicadditions/machines/multi/miner/MetaTileEntityVoidMiner.java
@@ -368,4 +368,20 @@ public class MetaTileEntityVoidMiner extends MultiblockWithDisplayBase {
         }
     }
 
+    public int getMaxTemperature() {
+        return maxTemperature;
+    }
+
+    public boolean isOverheat() {
+        return overheat;
+    }
+
+    public int getTemperature() {
+        return temperature;
+    }
+
+    public double getCurrentDrillingFluid() {
+        return currentDrillingFluid;
+    }
+
 }

--- a/src/main/java/gregicadditions/machines/multi/nuclear/MetaTileEntityNuclearReactor.java
+++ b/src/main/java/gregicadditions/machines/multi/nuclear/MetaTileEntityNuclearReactor.java
@@ -274,5 +274,12 @@ public class MetaTileEntityNuclearReactor extends RecipeMapMultiblockController 
         this.recipeBaseHeat = data.getInteger("recipeBaseHeat");
     }
 
+    public int getRecipeBaseHeat() {
+        return recipeBaseHeat;
+    }
+
+    public int getRodAdditionalTemperature() {
+        return rodAdditionalTemperature;
+    }
 
 }


### PR DESCRIPTION
Added some APIs about multi-block (worthy ones).
- `BatteryTower` (I/O per tick)
- `NuclearReactor` (coolant and heat)
- `VoidMiner` and `Fusion` (heat)
- `QubitContainer` for multi-blocks
- `Accelerator` (IControllable and interaction)

Small changes to `BatteryTower` have been made to support monitoring the energy per tick. I think this makes sense, especially requirements with GTCE digitization.