### PR TITLE
Supporting GT tools in AE2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,13 @@ minecraft {
     replaceIn("Gregicality.java")
 }
 
+jar {
+    manifest {
+        attributes 'FMLCorePluginContainsFMLMod': 'true'
+        attributes 'FMLCorePlugin': 'gregicadditions.coremod.GACoreMod'
+    }
+}
+
 repositories {
     maven {
         url = "http://dvs1.progwml6.com/files/maven/"
@@ -86,6 +93,7 @@ dependencies {
     deobfCompile "slimeknights:TConstruct:1.12.2-2.12.0.115"
     deobfCompile "mcjty.theoneprobe:TheOneProbe-1.12:1.12-1.4.23-16"
     deobfCompile "team.chisel.ctm:CTM:MC1.12.2-1.0.2.31"
+    provided 'appeng:appliedenergistics2:rv6-stable-7'
     provided "binnie:binnie-mods-1.12.2:2.5.1.184"
     provided "exnihilocreatio:exnihilocreatio:1.12.2-0.3.7.31"
     compileOnly files("libs/Cucumber-1.12.2-1.1.3.jar")

--- a/src/main/java/gregicadditions/coremod/GAClassTransformer.java
+++ b/src/main/java/gregicadditions/coremod/GAClassTransformer.java
@@ -1,0 +1,48 @@
+package gregicadditions.coremod;
+
+import gregicadditions.coremod.transform.PacketJEIRecipeTransformer;
+import net.minecraft.launchwrapper.IClassTransformer;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+
+public class GAClassTransformer implements IClassTransformer {
+    @Override
+    public byte[] transform(String name, String transformedName, byte[] basicClass) {
+        Transform tform;
+        switch (transformedName) {
+            case "appeng.core.sync.packets.PacketJEIRecipe":
+                tform = PacketJEIRecipeTransformer.INSTANCE;
+                break;
+            default:
+                return basicClass;
+        }
+        System.out.println("[Gregicality] Transforming class: " + transformedName);
+        return tform.transformClass(basicClass);
+    }
+
+    public interface Transform {
+
+        byte[] transformClass(byte[] code);
+
+    }
+
+    public static abstract class ClassMapper implements Transform {
+
+        @Override
+        public byte[]
+        transformClass(byte[] code) {
+            ClassReader reader = new ClassReader(code);
+            ClassWriter writer = new ClassWriter(reader, getWriteFlags());
+            reader.accept(getClassMapper(writer), 0);
+            return writer.toByteArray();
+        }
+
+        protected int getWriteFlags() {
+            return 0;
+        }
+
+        protected abstract ClassVisitor getClassMapper(ClassVisitor downstream);
+
+    }
+}

--- a/src/main/java/gregicadditions/coremod/GACoreMod.java
+++ b/src/main/java/gregicadditions/coremod/GACoreMod.java
@@ -1,0 +1,34 @@
+package gregicadditions.coremod;
+
+import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+
+public class GACoreMod implements IFMLLoadingPlugin {
+    @Override
+    public String[] getASMTransformerClass() {
+        return new String[] { GACoreMod.class.getPackage().getName() + ".GAClassTransformer" };
+    }
+
+    @Override
+    public String getModContainerClass() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getSetupClass() {
+        return null;
+    }
+
+    @Override
+    public void injectData(Map<String, Object> data) {
+
+    }
+
+    @Override
+    public String getAccessTransformerClass() {
+        return null;
+    }
+}

--- a/src/main/java/gregicadditions/coremod/hooks/CoreModHooks.java
+++ b/src/main/java/gregicadditions/coremod/hooks/CoreModHooks.java
@@ -1,0 +1,25 @@
+package gregicadditions.coremod.hooks;
+
+import appeng.api.config.Actionable;
+import appeng.api.networking.energy.IEnergySource;
+import appeng.api.networking.security.IActionSource;
+import appeng.api.storage.IMEMonitor;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.util.Platform;
+import gregtech.api.items.metaitem.MetaItem;
+
+public class CoreModHooks {
+
+    public static IAEItemStack poweredExtraction(IEnergySource energy, IMEMonitor<IAEItemStack> cell, IAEItemStack request, IActionSource src ) {
+        if (request != null && request.getDefinition().getItem() instanceof MetaItem){
+            for (IAEItemStack itemStack : cell.getStorageList()) {
+                if (itemStack.getItem() == request.getItem() && itemStack.getItemDamage() == request.getItemDamage() && itemStack.getDefinition().getCount() >= request.getDefinition().getCount()) {
+                    request.getDefinition().setTagCompound(itemStack.getDefinition().getTagCompound());
+                    break;
+                }
+            }
+        }
+        return Platform.poweredExtraction( energy, cell, request, src, Actionable.MODULATE );
+    }
+
+}

--- a/src/main/java/gregicadditions/coremod/transform/PacketJEIRecipeTransformer.java
+++ b/src/main/java/gregicadditions/coremod/transform/PacketJEIRecipeTransformer.java
@@ -1,0 +1,57 @@
+package gregicadditions.coremod.transform;
+
+import gregicadditions.coremod.GAClassTransformer;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class PacketJEIRecipeTransformer extends GAClassTransformer.ClassMapper {
+
+    public static final PacketJEIRecipeTransformer INSTANCE = new PacketJEIRecipeTransformer();
+
+    private PacketJEIRecipeTransformer() {
+        // NO-OP
+    }
+
+    @Override
+    protected ClassVisitor getClassMapper(ClassVisitor downstream) {
+        return new TransformPacketJEIRecipe(Opcodes.ASM5, downstream);
+    }
+
+    private static class TransformPacketJEIRecipe extends ClassVisitor {
+
+        TransformPacketJEIRecipe(int api, ClassVisitor cv) {
+            super(api, cv);
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+            if (name.equals("serverPacketData")) {
+                return new TransformPoweredExtraction(api, super.visitMethod(access, name, desc, signature, exceptions));
+            }
+            return super.visitMethod(access, name, desc, signature, exceptions);
+        }
+
+    }
+
+    private static class TransformPoweredExtraction extends MethodVisitor {
+
+        TransformPoweredExtraction(int api, MethodVisitor mv) {
+            super(api, mv);
+        }
+
+        @Override
+        public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
+            if (opcode == Opcodes.INVOKESTATIC && owner.equals("appeng/util/Platform") && name.equals("poweredExtraction")) {
+                super.visitMethodInsn(Opcodes.INVOKESTATIC,
+                        "gregicadditions/coremod/hooks/CoreModHooks",
+                        "poweredExtraction",
+                        "(Lappeng/api/networking/energy/IEnergySource;Lappeng/api/storage/IMEMonitor;Lappeng/api/storage/data/IAEItemStack;Lappeng/api/networking/security/IActionSource;)Lappeng/api/storage/data/IAEItemStack;",
+                        false);
+            } else {
+                super.visitMethodInsn(opcode, owner, name, desc, itf);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
This is a very simple coremod, almost no hacking of AE2. 
Feature: fixed an issue with NBT meta items (such as gt tools) that could not be recognized, when using JEI to import a recipe into the crafting terminal.

![ae2](https://user-images.githubusercontent.com/18493855/102801642-6fb0c580-43f0-11eb-95b4-6b9d6d823046.gif)
