### PR TITLE
Fix helium compatibility problem with NuclearCraft

### DIFF
--- a/src/main/java/gregicadditions/GAMaterials.java
+++ b/src/main/java/gregicadditions/GAMaterials.java
@@ -42,6 +42,7 @@ public class GAMaterials implements IMaterialHandler {
     public static long STD_METAL = GENERATE_PLATE;
     static long EXT2_METAL = GENERATE_PLATE | GENERATE_DENSE | GENERATE_ROD | GENERATE_BOLT_SCREW | GENERATE_GEAR | GENERATE_FOIL | GENERATE_FINE_WIRE | GENERATE_LONG_ROD;
     static long CORE_METAL = EXT2_METAL | GENERATE_RING | GENERATE_FRAME | GENERATE_ROTOR | GENERATE_SMALL_GEAR | GENERATE_DENSE;
+    public static final FluidMaterial LiquidHelium = new FluidMaterial(1000, "liquid_helium", Helium.materialRGB, MaterialIconSet.FLUID, of(), NO_RECYCLING | GENERATE_FLUID_BLOCK | DISABLE_DECOMPOSITION).setFluidTemperature(4);
     public static final FluidMaterial FishOil = new FluidMaterial(999, "fish_oil", 14467421, MaterialIconSet.FLUID, ImmutableList.of(), GENERATE_FLUID_BLOCK | DISABLE_DECOMPOSITION);
     public static final FluidMaterial RawGrowthMedium = new FluidMaterial(998, "raw_growth_medium", 10777425, MaterialIconSet.FLUID, ImmutableList.of(), GENERATE_FLUID_BLOCK | DISABLE_DECOMPOSITION);
     public static final FluidMaterial SterileGrowthMedium = new FluidMaterial(997, "sterilized_growth_medium", 11306862, MaterialIconSet.FLUID, ImmutableList.of(), GENERATE_FLUID_BLOCK | DISABLE_DECOMPOSITION);
@@ -552,7 +553,6 @@ public class GAMaterials implements IMaterialHandler {
     public static final SimpleDustMaterial LeadChloride = new SimpleDustMaterial("lead_chloride", 0xbf95f5, (short) 53, MaterialIconSet.SHINY, of(new MaterialStack(Lead, 1), new MaterialStack(Chlorine, 1)));
 
     public static final SimpleFluidMaterial ElectronDegenerateRheniumPlasma = new SimpleFluidMaterial("degenerate_rhenium_plasma", 0x6666FF);
-    public static final SimpleFluidMaterial LiquidHelium = new SimpleFluidMaterial("liquid_helium", Helium.materialRGB);
 
     public static final SimpleDustMaterial ZirconiumTetrafluoride = new SimpleDustMaterial("zirconium_tetrafluoride", 0xeeeeee, (short) 56, MaterialIconSet.DULL, of(new MaterialStack(Zirconium, 1), new MaterialStack(Fluorine, 6)));
     public static final SimpleDustMaterial BariumDifluoride = new SimpleDustMaterial("barium_difluoride", 0xdddddd, (short) 57, MaterialIconSet.DULL, of(new MaterialStack(Barium, 1), new MaterialStack(Fluorine, 2)));


### PR DESCRIPTION
**Issue**
With both GTCE and NuclearCraft installed, `liquid_helium` fluid is registered by GTCE but with different temperature
By default, GTCE Helium fluid has 300K of temperature while NC has only 4K.

According to https://github.com/turbodiesel4598/NuclearCraft/blob/master/src/main/java/nc/fluid/SuperFluid.java#L8 and https://github.com/turbodiesel4598/NuclearCraft/blob/6abd59c1d3dec75db6d60a439d36d91bad039ec9/src/main/java/nc/init/NCFluids.java#L49

Thus, [QMD](https://github.com/Lach01298/QMD) will be unable to cool itself down normally
![image](https://user-images.githubusercontent.com/6669365/104845928-e5864f00-5912-11eb-9ae3-fcb194422657.png)

**Workaround**
change to fluid material and set the temperature
(plus idk how to increase ID so please interview it)

**Temporal CraftTweaker solution**:
```javascript
#loader gregtech
import mods.gregtech.material.MaterialRegistry;
MaterialRegistry.createFluidMaterial(7891, "liquid_helium", 0xDDDD00, "gas").setFluidTemperature(4).addFlags(["STATE_GAS", "GENERATE_PLASMA"]);
```
 