### PR TITLE
Make regular fusion reactors use the matching casing and coil tier

### DIFF
--- a/src/main/java/gregicadditions/jei/FusionReactor1Info.java
+++ b/src/main/java/gregicadditions/jei/FusionReactor1Info.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import gregicadditions.machines.GATileEntities;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.common.blocks.BlockMachineCasing;
+import gregtech.common.blocks.BlockMultiblockCasing;
 import gregtech.common.blocks.BlockWireCoil;
 import gregtech.common.blocks.MetaBlocks;
 import gregtech.common.metatileentities.MetaTileEntities;
@@ -41,8 +42,8 @@ public class FusionReactor1Info extends MultiblockInfoPage {
 				.aisle("######DCD######", "####CCcccCC####", "######UCU######")
 				.aisle("###############", "######NMN######", "###############")
 				.where('M', GATileEntities.FUSION_REACTOR[0], EnumFacing.SOUTH)
-				.where('C', MetaBlocks.MACHINE_CASING.getState(BlockMachineCasing.MachineCasingType.LuV))
-				.where('c', MetaBlocks.WIRE_COIL.getState(BlockWireCoil.CoilType.SUPERCONDUCTOR))
+				.where('C', MetaBlocks.MUTLIBLOCK_CASING.getState(BlockMultiblockCasing.MultiblockCasingType.FUSION_CASING))
+				.where('c', MetaBlocks.WIRE_COIL.getState(BlockWireCoil.CoilType.FUSION_COIL))
 				.where('W', MetaTileEntities.FLUID_EXPORT_HATCH[6], EnumFacing.WEST)
 				.where('E', MetaTileEntities.FLUID_EXPORT_HATCH[6], EnumFacing.EAST)
 				.where('S', MetaTileEntities.FLUID_EXPORT_HATCH[6], EnumFacing.SOUTH)

--- a/src/main/java/gregicadditions/jei/FusionReactor2Info.java
+++ b/src/main/java/gregicadditions/jei/FusionReactor2Info.java
@@ -1,6 +1,8 @@
 package gregicadditions.jei;
 
 import com.google.common.collect.Lists;
+import gregicadditions.item.GAMetaBlocks;
+import gregicadditions.item.fusion.GAFusionCasing;
 import gregicadditions.machines.GATileEntities;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.common.blocks.BlockMultiblockCasing;
@@ -24,7 +26,37 @@ public class FusionReactor2Info extends MultiblockInfoPage {
 
 	@Override
 	public List<MultiblockShapeInfo> getMatchingShapes() {
-		MultiblockShapeInfo shapeInfo = MultiblockShapeInfo.builder().aisle("###############", "######NCN######", "###############").aisle("######DCD######", "####CCcccCC####", "######UCU######").aisle("####CC###CC####", "###sccNCNccs###", "####CC###CC####").aisle("###C#######C###", "##wcnC###Cnce##", "###C#######C###").aisle("##C#########C##", "#Cce#######wcC#", "##C#########C##").aisle("##C#########C##", "#CcC#######CcC#", "##C#########C##").aisle("#D###########D#", "WcE#########WcE", "#U###########U#").aisle("#C###########C#", "CcC#########CcC", "#C###########C#").aisle("#D###########D#", "WcE#########WcE", "#U###########U#").aisle("##C#########C##", "#CcC#######CcC#", "##C#########C##").aisle("##C#########C##", "#Cce#######wcC#", "##C#########C##").aisle("###C#######C###", "##wcsC###Csce##", "###C#######C###").aisle("####CC###CC####", "###nccSCSccn###", "####CC###CC####").aisle("######DCD######", "####CCcccCC####", "######UCU######").aisle("###############", "######NMN######", "###############").where('M', GATileEntities.FUSION_REACTOR[1], EnumFacing.SOUTH).where('C', MetaBlocks.MUTLIBLOCK_CASING.getState(BlockMultiblockCasing.MultiblockCasingType.FUSION_CASING)).where('c', MetaBlocks.WIRE_COIL.getState(BlockWireCoil.CoilType.FUSION_COIL)).where('W', MetaTileEntities.FLUID_EXPORT_HATCH[7], EnumFacing.WEST).where('E', MetaTileEntities.FLUID_EXPORT_HATCH[7], EnumFacing.EAST).where('S', MetaTileEntities.FLUID_EXPORT_HATCH[7], EnumFacing.SOUTH).where('N', MetaTileEntities.FLUID_EXPORT_HATCH[7], EnumFacing.NORTH).where('w', MetaTileEntities.ENERGY_INPUT_HATCH[7], EnumFacing.WEST).where('e', MetaTileEntities.ENERGY_INPUT_HATCH[7], EnumFacing.EAST).where('s', MetaTileEntities.ENERGY_INPUT_HATCH[7], EnumFacing.SOUTH).where('n', MetaTileEntities.ENERGY_INPUT_HATCH[7], EnumFacing.NORTH).where('U', MetaTileEntities.FLUID_IMPORT_HATCH[7], EnumFacing.UP).where('D', MetaTileEntities.FLUID_IMPORT_HATCH[7], EnumFacing.DOWN).where('#', Blocks.AIR.getDefaultState()).build();
+		MultiblockShapeInfo shapeInfo = MultiblockShapeInfo.builder()
+				.aisle("###############", "######NCN######", "###############")
+				.aisle("######DCD######", "####CCcccCC####", "######UCU######")
+				.aisle("####CC###CC####", "###sccNCNccs###", "####CC###CC####")
+				.aisle("###C#######C###", "##wcnC###Cnce##", "###C#######C###")
+				.aisle("##C#########C##", "#Cce#######wcC#", "##C#########C##")
+				.aisle("##C#########C##", "#CcC#######CcC#", "##C#########C##")
+				.aisle("#D###########D#", "WcE#########WcE", "#U###########U#")
+				.aisle("#C###########C#", "CcC#########CcC", "#C###########C#")
+				.aisle("#D###########D#", "WcE#########WcE", "#U###########U#")
+				.aisle("##C#########C##", "#CcC#######CcC#", "##C#########C##")
+				.aisle("##C#########C##", "#Cce#######wcC#", "##C#########C##")
+				.aisle("###C#######C###", "##wcsC###Csce##", "###C#######C###")
+				.aisle("####CC###CC####", "###nccSCSccn###", "####CC###CC####")
+				.aisle("######DCD######", "####CCcccCC####", "######UCU######")
+				.aisle("###############", "######NMN######", "###############")
+				.where('M', GATileEntities.FUSION_REACTOR[1], EnumFacing.SOUTH)
+				.where('C', MetaBlocks.MUTLIBLOCK_CASING.getState(BlockMultiblockCasing.MultiblockCasingType.FUSION_CASING_MK2))
+				.where('c', GAMetaBlocks.FUSION_CASING.getState(GAFusionCasing.CasingType.FUSION_COIL_2))
+				.where('W', MetaTileEntities.FLUID_EXPORT_HATCH[7], EnumFacing.WEST)
+				.where('E', MetaTileEntities.FLUID_EXPORT_HATCH[7], EnumFacing.EAST)
+				.where('S', MetaTileEntities.FLUID_EXPORT_HATCH[7], EnumFacing.SOUTH)
+				.where('N', MetaTileEntities.FLUID_EXPORT_HATCH[7], EnumFacing.NORTH)
+				.where('w', MetaTileEntities.ENERGY_INPUT_HATCH[7], EnumFacing.WEST)
+				.where('e', MetaTileEntities.ENERGY_INPUT_HATCH[7], EnumFacing.EAST)
+				.where('s', MetaTileEntities.ENERGY_INPUT_HATCH[7], EnumFacing.SOUTH)
+				.where('n', MetaTileEntities.ENERGY_INPUT_HATCH[7], EnumFacing.NORTH)
+				.where('U', MetaTileEntities.FLUID_IMPORT_HATCH[7], EnumFacing.UP)
+				.where('D', MetaTileEntities.FLUID_IMPORT_HATCH[7], EnumFacing.DOWN)
+				.where('#', Blocks.AIR.getDefaultState())
+				.build();
 
 		return Lists.newArrayList(shapeInfo);
 	}

--- a/src/main/java/gregicadditions/jei/FusionReactor3Info.java
+++ b/src/main/java/gregicadditions/jei/FusionReactor3Info.java
@@ -1,6 +1,8 @@
 package gregicadditions.jei;
 
 import com.google.common.collect.Lists;
+import gregicadditions.item.GAMetaBlocks;
+import gregicadditions.item.fusion.GAFusionCasing;
 import gregicadditions.machines.GATileEntities;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.common.blocks.BlockMultiblockCasing;
@@ -41,8 +43,8 @@ public class FusionReactor3Info extends MultiblockInfoPage {
 				.aisle("######DCD######", "####CCcccCC####", "######UCU######")
 				.aisle("###############", "######NMN######", "###############")
 				.where('M', GATileEntities.FUSION_REACTOR[2], EnumFacing.SOUTH)
-				.where('C', MetaBlocks.MUTLIBLOCK_CASING.getState(BlockMultiblockCasing.MultiblockCasingType.FUSION_CASING_MK2))
-				.where('c', MetaBlocks.WIRE_COIL.getState(BlockWireCoil.CoilType.FUSION_COIL))
+				.where('C', GAMetaBlocks.FUSION_CASING.getState(GAFusionCasing.CasingType.FUSION_3))
+				.where('c', GAMetaBlocks.FUSION_CASING.getState(GAFusionCasing.CasingType.FUSION_COIL_3))
 				.where('W', MetaTileEntities.FLUID_EXPORT_HATCH[8], EnumFacing.WEST)
 				.where('E', MetaTileEntities.FLUID_EXPORT_HATCH[8], EnumFacing.EAST)
 				.where('S', MetaTileEntities.FLUID_EXPORT_HATCH[8], EnumFacing.SOUTH)

--- a/src/main/java/gregicadditions/machines/multi/TileEntityFusionReactor.java
+++ b/src/main/java/gregicadditions/machines/multi/TileEntityFusionReactor.java
@@ -7,6 +7,8 @@ import gregicadditions.GAValues;
 import gregicadditions.capabilities.impl.GAMultiblockRecipeLogic;
 import gregicadditions.capabilities.impl.GARecipeMapMultiblockController;
 import gregicadditions.client.ClientHandler;
+import gregicadditions.item.GAMetaBlocks;
+import gregicadditions.item.fusion.GAFusionCasing;
 import gregtech.api.GTValues;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.capability.IMultipleTankHandler;
@@ -105,23 +107,24 @@ public class TileEntityFusionReactor extends GARecipeMapMultiblockController {
     private IBlockState getCasingState() {
         switch (tier) {
             case 6:
-                return MetaBlocks.MACHINE_CASING.getState(BlockMachineCasing.MachineCasingType.LuV);
-            case 7:
                 return MetaBlocks.MUTLIBLOCK_CASING.getState(BlockMultiblockCasing.MultiblockCasingType.FUSION_CASING);
+            case 7:
+                return MetaBlocks.MUTLIBLOCK_CASING.getState(BlockMultiblockCasing.MultiblockCasingType.FUSION_CASING_MK2);
             case 8:
             default:
-                return MetaBlocks.MUTLIBLOCK_CASING.getState(BlockMultiblockCasing.MultiblockCasingType.FUSION_CASING_MK2);
+                return GAMetaBlocks.FUSION_CASING.getState(GAFusionCasing.CasingType.FUSION_3);
         }
     }
 
     private IBlockState getCoilState() {
         switch (tier) {
             case 6:
-                return MetaBlocks.WIRE_COIL.getState(BlockWireCoil.CoilType.SUPERCONDUCTOR);
+                return MetaBlocks.WIRE_COIL.getState(BlockWireCoil.CoilType.FUSION_COIL);
             case 7:
+                return GAMetaBlocks.FUSION_CASING.getState(GAFusionCasing.CasingType.FUSION_COIL_2);
             case 8:
             default:
-                return MetaBlocks.WIRE_COIL.getState(BlockWireCoil.CoilType.FUSION_COIL);
+                return GAMetaBlocks.FUSION_CASING.getState(GAFusionCasing.CasingType.FUSION_COIL_3);
         }
     }
 

--- a/src/main/java/gregicadditions/recipes/GARecipeAddition.java
+++ b/src/main/java/gregicadditions/recipes/GARecipeAddition.java
@@ -9,6 +9,7 @@ import gregicadditions.GAMaterials;
 import gregicadditions.armor.PowerlessJetpack;
 import gregicadditions.item.*;
 import gregicadditions.item.components.*;
+import gregicadditions.item.fusion.GAFusionCasing;
 import gregicadditions.machines.GATileEntities;
 import gregicadditions.recipes.chain.*;
 import gregicadditions.recipes.chain.wetware.*;
@@ -65,6 +66,7 @@ import static gregicadditions.recipes.GARecipeMaps.*;
 import static gregtech.api.recipes.RecipeMaps.*;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.ore.OrePrefix.*;
+import static gregtech.common.blocks.BlockMachineCasing.MachineCasingType.LuV;
 import static gregtech.common.items.MetaItems.*;
 
 public class GARecipeAddition {
@@ -821,10 +823,12 @@ public class GARecipeAddition {
         ADV_FUSION_RECIPES.recipeBuilder().fluidInputs(Curium247.getMaterial().getFluid(144), Sodium.getFluid(144)).fluidOutputs(Bohrium.getFluid(288)).duration(50).EUt(1000000).euStart(1000000000).coilTier(1).euReturn(40).buildAndRegister();
         ADV_FUSION_RECIPES.recipeBuilder().fluidInputs(Trinium.getFluid(144), Tritanium.getFluid(144)).fluidOutputs(Adamantium.getFluid(288)).duration(100).EUt(2000000).coilTier(1).euStart(1000000000).euReturn(40).buildAndRegister();
         ADV_FUSION_RECIPES.recipeBuilder().fluidInputs(Adamantium.getFluid(144), Seaborgium.getFluid(144)).fluidOutputs(Vibranium.getFluid(288)).duration(100).EUt(8000000).coilTier(2).euStart(2500000000L).euReturn(40).buildAndRegister();
-        //FUsion Casing Recipes
-        ModHandler.addShapedRecipe("fusion_casing_1", MetaBlocks.MUTLIBLOCK_CASING.getItemVariant(MultiblockCasingType.FUSION_CASING), "PhP", "PHP", "PwP", 'P', "plateTungstenSteel", 'H', MetaBlocks.MACHINE_CASING.getItemVariant(BlockMachineCasing.MachineCasingType.LuV));
-        ModHandler.addShapedRecipe("fusion_casing_2", MetaBlocks.MUTLIBLOCK_CASING.getItemVariant(MultiblockCasingType.FUSION_CASING_MK2), "PhP", "PHP", "PwP", 'P', "plateDubnium", 'H', MetaBlocks.MUTLIBLOCK_CASING.getItemVariant(MultiblockCasingType.FUSION_CASING));
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(16).inputs(MetaBlocks.MUTLIBLOCK_CASING.getItemVariant(MultiblockCasingType.FUSION_CASING)).input(plate, Dubnium, 6).outputs(MetaBlocks.MUTLIBLOCK_CASING.getItemVariant(MultiblockCasingType.FUSION_CASING_MK2)).duration(50).buildAndRegister();
+        //Fusion Casing Recipes
+        ModHandler.addShapedRecipe("fusion_casing_1", MetaBlocks.MUTLIBLOCK_CASING.getItemVariant(MultiblockCasingType.FUSION_CASING), "PhP", "PHP", "PwP", 'P', "plateTungstenSteel", 'H', MetaBlocks.MACHINE_CASING.getItemVariant(LuV));
+        ModHandler.addShapedRecipe("fusion_casing_2", MetaBlocks.MUTLIBLOCK_CASING.getItemVariant(MultiblockCasingType.FUSION_CASING_MK2), "PhP", "PHP", "PwP", 'P', "plateRutherfordium", 'H', MetaBlocks.MUTLIBLOCK_CASING.getItemVariant(MultiblockCasingType.FUSION_CASING));
+        ModHandler.addShapedRecipe("fusion_casing_3", GAMetaBlocks.FUSION_CASING.getItemVariant(GAFusionCasing.CasingType.FUSION_3), "PhP", "PHP", "PwP", 'P', "plateDubnium", 'H', MetaBlocks.MUTLIBLOCK_CASING.getItemVariant(MultiblockCasingType.FUSION_CASING_MK2));
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(16).inputs(MetaBlocks.MUTLIBLOCK_CASING.getItemVariant(MultiblockCasingType.FUSION_CASING)).input(plate, Rutherfordium, 6).outputs(MetaBlocks.MUTLIBLOCK_CASING.getItemVariant(MultiblockCasingType.FUSION_CASING_MK2)).duration(50).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(16).inputs(MetaBlocks.MUTLIBLOCK_CASING.getItemVariant(MultiblockCasingType.FUSION_CASING_MK2)).input(plate, Dubnium, 6).outputs(GAMetaBlocks.FUSION_CASING.getItemVariant(GAFusionCasing.CasingType.FUSION_3)).duration(50).buildAndRegister();
 
         ModHandler.addShapedRecipe("fusion_coil", MetaBlocks.WIRE_COIL.getItemVariant(BlockWireCoil.CoilType.FUSION_COIL), "CRC", "FSF", "CRC", 'C', "circuitMaster", 'R', NEUTRON_REFLECTOR.getStackForm(), 'F', FIELD_GENERATOR_ZPM.getStackForm(), 'S', OreDictUnifier.get(cableGtOctal, ZPMSuperconductor));
 

--- a/src/main/java/gregicadditions/recipes/GARecipeAddition.java
+++ b/src/main/java/gregicadditions/recipes/GARecipeAddition.java
@@ -830,7 +830,11 @@ public class GARecipeAddition {
         ASSEMBLER_RECIPES.recipeBuilder().EUt(16).inputs(MetaBlocks.MUTLIBLOCK_CASING.getItemVariant(MultiblockCasingType.FUSION_CASING)).input(plate, Rutherfordium, 6).outputs(MetaBlocks.MUTLIBLOCK_CASING.getItemVariant(MultiblockCasingType.FUSION_CASING_MK2)).duration(50).buildAndRegister();
         ASSEMBLER_RECIPES.recipeBuilder().EUt(16).inputs(MetaBlocks.MUTLIBLOCK_CASING.getItemVariant(MultiblockCasingType.FUSION_CASING_MK2)).input(plate, Dubnium, 6).outputs(GAMetaBlocks.FUSION_CASING.getItemVariant(GAFusionCasing.CasingType.FUSION_3)).duration(50).buildAndRegister();
 
-        ModHandler.addShapedRecipe("fusion_coil", MetaBlocks.WIRE_COIL.getItemVariant(BlockWireCoil.CoilType.FUSION_COIL), "CRC", "FSF", "CRC", 'C', "circuitMaster", 'R', NEUTRON_REFLECTOR.getStackForm(), 'F', FIELD_GENERATOR_ZPM.getStackForm(), 'S', OreDictUnifier.get(cableGtOctal, ZPMSuperconductor));
+        // Fusion Coil Recipes
+        ASSEMBLY_LINE_RECIPES.recipeBuilder().EUt(30720).inputs(NEUTRON_REFLECTOR.getStackForm(2), FIELD_GENERATOR_LUV.getStackForm(), OreDictUnifier.get(cableGtQuadruple, LuVSuperconductor, 4), OreDictUnifier.get(plate, Osmiridium, 2)).input(circuit, Tier.Master, 1).fluidInputs(Helium.getFluid(4000)).outputs(MetaBlocks.WIRE_COIL.getItemVariant(BlockWireCoil.CoilType.FUSION_COIL)).duration(400).buildAndRegister();
+        ASSEMBLY_LINE_RECIPES.recipeBuilder().EUt(122880).inputs(NEUTRON_REFLECTOR.getStackForm(4), FIELD_GENERATOR_ZPM.getStackForm(), OreDictUnifier.get(cableGtQuadruple, ZPMSuperconductor, 4), OreDictUnifier.get(plate, Rutherfordium, 2)).input(circuit, Tier.Ultimate, 1).fluidInputs(Helium.getFluid(4000)).outputs(GAMetaBlocks.FUSION_CASING.getItemVariant(GAFusionCasing.CasingType.FUSION_COIL_2)).duration(400).buildAndRegister();
+        ASSEMBLY_LINE_RECIPES.recipeBuilder().EUt(491520).inputs(NEUTRON_REFLECTOR.getStackForm(6), FIELD_GENERATOR_ZPM.getStackForm(2), OreDictUnifier.get(cableGtQuadruple, UVSuperconductor, 4), OreDictUnifier.get(plate, Tritanium, 2)).input(circuit, Tier.Superconductor, 1).fluidInputs(Helium.getFluid(4000)).outputs(GAMetaBlocks.FUSION_CASING.getItemVariant(GAFusionCasing.CasingType.FUSION_COIL_3)).duration(400).buildAndRegister();
+
 
         MIXER_RECIPES.recipeBuilder()
                 .input(dust, Iron, 4)

--- a/src/main/java/gregicadditions/recipes/MachineCraftingRecipes.java
+++ b/src/main/java/gregicadditions/recipes/MachineCraftingRecipes.java
@@ -6,6 +6,7 @@ import gregicadditions.GAMaterials;
 import gregicadditions.GAValues;
 import gregicadditions.item.*;
 import gregicadditions.item.components.MotorCasing;
+import gregicadditions.item.fusion.GAFusionCasing;
 import gregicadditions.machines.GATileEntities;
 import gregicadditions.machines.energyconverter.utils.EnergyConverterCraftingHelper;
 import gregicadditions.machines.energyconverter.utils.EnergyConverterType;
@@ -466,7 +467,7 @@ public class MachineCraftingRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(2880))
                 .outputs(GATileEntities.FUSION_REACTOR[0].getStackForm()).buildAndRegister();
         ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(1000).EUt(60000)
-                .inputs(MetaBlocks.WIRE_COIL.getItemVariant(BlockWireCoil.CoilType.FUSION_COIL),
+                .inputs(GAMetaBlocks.FUSION_CASING.getItemVariant(GAFusionCasing.CasingType.FUSION_COIL_2),
                         OreDictUnifier.get(plate, Rutherfordium, 4),
                         OreDictUnifier.get(plate, Curium.getMaterial(), 4),
                         FIELD_GENERATOR_LUV.getStackForm(2),
@@ -479,7 +480,7 @@ public class MachineCraftingRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(2880))
                 .outputs(GATileEntities.FUSION_REACTOR[1].getStackForm()).buildAndRegister();
         ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(1000).EUt(90000)
-                .inputs(MetaBlocks.WIRE_COIL.getItemVariant(BlockWireCoil.CoilType.FUSION_COIL),
+                .inputs(GAMetaBlocks.FUSION_CASING.getItemVariant(GAFusionCasing.CasingType.FUSION_COIL_3),
                         OreDictUnifier.get(plate, Dubnium, 4),
                         OreDictUnifier.get(plate, Californium.getMaterial(), 4),
                         FIELD_GENERATOR_ZPM.getStackForm(2),

--- a/src/main/java/gregicadditions/recipes/chain/FusionComponents.java
+++ b/src/main/java/gregicadditions/recipes/chain/FusionComponents.java
@@ -172,7 +172,7 @@ public class FusionComponents {
                 .outputs(GAMetaBlocks.CRYOSTAT_CASING.getItemVariant(GACryostatCasing.CasingType.CRYOSTAT_3, 4))
                 .buildAndRegister();
         ASSEMBLER_RECIPES.recipeBuilder().EUt(500000).
-                inputs(GAMetaBlocks.FUSION_CASING.getItemVariant(GAFusionCasing.CasingType.FUSION_COIL_3))
+                inputs(GAMetaBlocks.FUSION_CASING.getItemVariant(GAFusionCasing.CasingType.FUSION_3))
                 .input(plate, TantalumHafniumSeaborgiumCarbide, 6)
                 .outputs(GAMetaBlocks.FUSION_CASING.getItemVariant(GAFusionCasing.CasingType.ADV_FUSION_CASING))
                 .duration(50)

--- a/src/main/java/gregicadditions/recipes/chain/FusionComponents.java
+++ b/src/main/java/gregicadditions/recipes/chain/FusionComponents.java
@@ -172,7 +172,7 @@ public class FusionComponents {
                 .outputs(GAMetaBlocks.CRYOSTAT_CASING.getItemVariant(GACryostatCasing.CasingType.CRYOSTAT_3, 4))
                 .buildAndRegister();
         ASSEMBLER_RECIPES.recipeBuilder().EUt(500000).
-                inputs(MetaBlocks.MUTLIBLOCK_CASING.getItemVariant(BlockMultiblockCasing.MultiblockCasingType.FUSION_CASING_MK2))
+                inputs(GAMetaBlocks.FUSION_CASING.getItemVariant(GAFusionCasing.CasingType.FUSION_COIL_3))
                 .input(plate, TantalumHafniumSeaborgiumCarbide, 6)
                 .outputs(GAMetaBlocks.FUSION_CASING.getItemVariant(GAFusionCasing.CasingType.ADV_FUSION_CASING))
                 .duration(50)


### PR DESCRIPTION
Modified the Fusion Reactors Mk. 1-3 to use Mk 1, Mk 2, and Mk 3 casings and coils respectively. Also updated the JEI previews to reflect this. Changed the recipes for the fusion casings 2 and 3 to reflect the new tearing. Mk 2 uses Rutherfordium, and Mk 3 uses Dubnium. Fusion coil recipes were updated as well, using LuV, ZPM, and UV power in the Assembly Line for the appropriate tier.