### PR TITLE
Fix cupriavidus necator culture ID and internal name

### DIFF
--- a/src/main/java/gregicadditions/item/GAMetaItem.java
+++ b/src/main/java/gregicadditions/item/GAMetaItem.java
@@ -409,7 +409,6 @@ public class GAMetaItem extends MaterialMetaItem {
         COSMIC_PROCESSING_UNIT_CORE = addItem(538,"cosmic_processing_unit_core");
         COSMIC_PROCESSING_CORE = addItem(539,"cosmic_processing_core");
         GRAPHENE_IRON_PLATE = addItem(540,"graphene_iron_plate");
-        CUPRIVADUS_CULTURE = addItem(541, "cupriavidus.culture");
 
         SMD_CAPACITOR_SUPRACAUSAL = addItem(541, "smd.capacitor.supracausal");
         SMD_RESISTOR_SUPRACAUSAL = addItem(542, "smd.resistor.supracausal");
@@ -433,6 +432,7 @@ public class GAMetaItem extends MaterialMetaItem {
         EIGENFOLDED_KERR_MANIFOLD = addItem(558, "eigenfolded.kerr.manifold");
         CTC_COMPUTATIONAL_UNIT = addItem(559, "ctc.computational.unit");
         RECURSIVELY_FOLDED_NEGATIVE_SPACE = addItem(560, "recursively.folded.negative.space");
+        CUPRIAVIDUS_CULTURE = addItem(561, "cupriavidus.culture");
 
         ThoriumRadioactive.waste = THORIUM_WASTE;
         Protactinium.waste = PROTACTINIUM_WASTE;

--- a/src/main/java/gregicadditions/item/GAMetaItems.java
+++ b/src/main/java/gregicadditions/item/GAMetaItems.java
@@ -308,7 +308,7 @@ public class GAMetaItems {
     public static MetaItem<?>.MetaValueItem ESCHERICHIA_CULTURE;
     public static MetaItem<?>.MetaValueItem BIFIDOBACTERIUM_CULTURE;
     public static MetaItem<?>.MetaValueItem BREVIBACTERIUM_CULTURE;
-    public static MetaItem<?>.MetaValueItem CUPRIVADUS_CULTURE;
+    public static MetaItem<?>.MetaValueItem CUPRIAVIDUS_CULTURE;
 
     public static MetaItem<?>.MetaValueItem BATTERY_SMALL_VANADIUM_EMPTY;
     public static MetaItem<?>.MetaValueItem BATTERY_SMALL_VANADIUM;


### PR DESCRIPTION
Resolves ID conflict created with the cosmic circuits. Also fixes misspelled internal name. 