### PR TITLE
Transformer TOP Update

### DIFF
--- a/src/main/java/gregicadditions/theoneprobe/GATransformerProvider.java
+++ b/src/main/java/gregicadditions/theoneprobe/GATransformerProvider.java
@@ -1,0 +1,67 @@
+package gregicadditions.theoneprobe;
+
+import gregicadditions.GAUtility;
+import gregicadditions.GAValues;
+import gregicadditions.machines.energy.GAMetaTileEntityTransformer;
+import gregtech.api.capability.IEnergyContainer;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.integration.theoneprobe.provider.ElectricContainerInfoProvider;
+import mcjty.theoneprobe.api.ElementAlignment;
+import mcjty.theoneprobe.api.IProbeInfo;
+import mcjty.theoneprobe.api.TextStyleClass;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+
+public class GATransformerProvider extends ElectricContainerInfoProvider {
+
+    @Override
+    public String getID () {
+        return "gtadditions:transformer_info_provider";
+    }
+
+    @Override
+    protected void addProbeInfo(IEnergyContainer capability, IProbeInfo probeInfo, TileEntity tileEntity, EnumFacing sideHit) {
+        if (tileEntity instanceof MetaTileEntityHolder) {
+            MetaTileEntity metaTileEntity = ((MetaTileEntityHolder) tileEntity).getMetaTileEntity();
+            if (metaTileEntity instanceof GAMetaTileEntityTransformer) {
+                GAMetaTileEntityTransformer mteTransformer = (GAMetaTileEntityTransformer)metaTileEntity;
+                String inputVoltageN = GAValues.VN[GAUtility.getTierByVoltage(capability.getInputVoltage())];
+                String outputVoltageN = GAValues.VN[GAUtility.getTierByVoltage(capability.getOutputVoltage())];
+                long inputAmperage = capability.getInputAmperage();
+                long outputAmperage = capability.getOutputAmperage();
+                IProbeInfo horizontalPane = probeInfo.vertical(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
+                String transformInfo;
+
+                // Step Up/Step Down line
+                String transformUpKey = "gregtech.top.transform_up";
+                String transformDownKey = "gregtech.top.transform_down";
+                if (mteTransformer.isInverted()) {
+                    transformInfo = I18n.format(transformUpKey,
+                            inputVoltageN, inputAmperage, outputVoltageN, outputAmperage);
+                } else {
+                    transformInfo = I18n.format(transformDownKey,
+                            inputVoltageN, inputAmperage, outputVoltageN, outputAmperage);
+                }
+
+                // Gets hit if our GT version is below 1.11.1
+                if (transformInfo.equals(transformUpKey)
+                        || transformInfo.equals(transformDownKey)) {
+                    return;
+                }
+                horizontalPane.text(TextStyleClass.INFO + transformInfo);
+
+                // Input/Output side line
+                horizontalPane = probeInfo.vertical(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
+                if (capability.inputsEnergy(sideHit)) {
+                    transformInfo = I18n.format("gregtech.top.transform_input", inputVoltageN, inputAmperage);
+                    horizontalPane.text(TextStyleClass.INFO + transformInfo);
+                } else if (capability.outputsEnergy(sideHit)) {
+                    transformInfo = I18n.format("gregtech.top.transform_output", outputVoltageN, outputAmperage);
+                    horizontalPane.text(TextStyleClass.INFO + transformInfo);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/gregicadditions/theoneprobe/TheOneProbeCompatibility.java
+++ b/src/main/java/gregicadditions/theoneprobe/TheOneProbeCompatibility.java
@@ -9,5 +9,6 @@ public class TheOneProbeCompatibility {
         ITheOneProbe oneProbe = TheOneProbe.theOneProbeImp;
         oneProbe.registerProvider(new MultiRecipeProvider());
         oneProbe.registerProvider(new QubitContainerInfoProvider());
+        oneProbe.registerProvider(new GATransformerProvider());
     }
 }


### PR DESCRIPTION
This PR updates our TOP info for transformers to be consistent with the new information displayed in GTCE. I felt it was redundant to add new localization keys since they already existed in GTCE's lang files, but this meant that the key would only resolve if the GTCE version is 1.11.1 or greater.

If GTCE 1.11.1+ is loaded:
![gtce1 11 1](https://user-images.githubusercontent.com/10861407/106863897-c74c7d00-668e-11eb-82fb-e6d17e1c76b1.png)

If a lower version is loaded (1.8 as is in my dev environment):
![gtce1 8 x](https://user-images.githubusercontent.com/10861407/106863930-d5020280-668e-11eb-8182-88e92678985f.png)

If you would like me to change this to not require GTCE 1.11.1+, it would be an easy fix, but would just mean redundant lang entries. Personally, I think it is okay that we do not show this information if GTCE does not either.