### PR TITLE
Steam Oven

### DIFF
--- a/src/main/java/gregicadditions/GAConfig.java
+++ b/src/main/java/gregicadditions/GAConfig.java
@@ -460,6 +460,7 @@ public class GAConfig {
         public AdvFusion advFusion = new AdvFusion();
         public LargeEngraver largeEngraver = new LargeEngraver();
         public HeatingCoils heatingCoils = new HeatingCoils();
+        public SteamMultis steamMultis = new SteamMultis();
     }
 
         public static class LargeEngraver {
@@ -1384,4 +1385,10 @@ public class GAConfig {
                 GALog.logger.info("Added resevoir type " + fluid);
             }
         }
+
+    public static class SteamMultis {
+        @Config.Comment({"Steam to EU multiplier for steam multiblocks. 1.0 means 1 Steam -> 1EU. 2.0 means 1 Steam -> 2EU. 0.5 means 2 Steam -> 1EU"})
+        @Config.RequiresMcRestart
+        public static double steamToEU = 0.5;
     }
+}

--- a/src/main/java/gregicadditions/capabilities/impl/RecipeMapSteamMultiblockController.java
+++ b/src/main/java/gregicadditions/capabilities/impl/RecipeMapSteamMultiblockController.java
@@ -111,7 +111,7 @@ public abstract class RecipeMapSteamMultiblockController extends MultiblockWithD
             }
 
             if (recipeMapWorkable.isHasNotEnoughEnergy()) {
-                textList.add(new TextComponentTranslation("gtadditions.multiblock.steam_grinder.low_steam").setStyle(new Style().setColor(TextFormatting.RED)));
+                textList.add(new TextComponentTranslation("gtadditions.multiblock.steam.low_steam").setStyle(new Style().setColor(TextFormatting.RED)));
             }
         }
     }

--- a/src/main/java/gregicadditions/capabilities/impl/SteamMultiWorkable.java
+++ b/src/main/java/gregicadditions/capabilities/impl/SteamMultiWorkable.java
@@ -1,0 +1,152 @@
+package gregicadditions.capabilities.impl;
+
+import gregtech.api.capability.IMultipleTankHandler;
+import gregtech.api.capability.impl.FluidTankList;
+import gregtech.api.recipes.CountableIngredient;
+import gregtech.api.recipes.Recipe;
+import gregtech.api.util.InventoryUtils;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.IItemHandlerModifiable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * General Recipe Handler for Steam Multiblocks.
+ * Will do up to the passed value of items in one process.
+ * Not recommended to use this Handler if you do not
+ * need multi-recipe logic for your Multi.
+ */
+public class SteamMultiWorkable extends SteamMultiblockRecipeLogic {
+
+    private final int MAX_PROCESSES;
+
+    public SteamMultiWorkable(RecipeMapSteamMultiblockController tileEntity, double conversionRate, int maxProcesses) {
+        super(tileEntity, tileEntity.recipeMap, tileEntity.getSteamFluidTank(), conversionRate);
+        MAX_PROCESSES = maxProcesses;
+    }
+
+    @Override
+    protected void trySearchNewRecipe() {
+        long maxVoltage = getMaxVoltage(); // Will always be LV voltage
+        Recipe currentRecipe = null;
+        IItemHandlerModifiable importInventory = getInputInventory();
+        boolean dirty = checkRecipeInputsDirty(importInventory, null);
+
+        if(dirty || forceRecipeRecheck) {
+            this.forceRecipeRecheck = false;
+
+            currentRecipe = findRecipe(maxVoltage, importInventory, null);
+            if (currentRecipe != null) {
+                this.previousRecipe = currentRecipe;
+            }
+        } else if (previousRecipe != null && previousRecipe.matches(false, importInventory, new FluidTankList(false))) {
+            currentRecipe = previousRecipe;
+        }
+
+        if (currentRecipe != null && setupAndConsumeRecipeInputs(currentRecipe)) {
+            setupRecipe(currentRecipe);
+        }
+    }
+
+    @Override
+    protected Recipe findRecipe(long maxVoltage, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs) {
+        int currentItemsEngaged = 0;
+        final ArrayList<CountableIngredient> recipeInputs = new ArrayList<>();
+        final ArrayList<ItemStack> recipeOutputs = new ArrayList<>();
+        int recipeEUt = 0;
+        int recipeDuration = 1;
+        float speedBonusPercent = 0.0F; // Currently unused
+
+        /* Iterate over input items looking for more items to process until we
+         * have touched every item, or are at maximum item capacity
+         */
+        for (int index = 0; index < inputs.getSlots() && currentItemsEngaged < MAX_PROCESSES; index ++) {
+            final ItemStack currentInputItem = inputs.getStackInSlot(index);
+
+            // Skip slot if empty
+            if (currentInputItem.isEmpty())
+                continue;
+
+            // Check recipe for item in slot
+            Recipe matchingRecipe = recipeMap.findRecipe(maxVoltage,
+                    Collections.singletonList(currentInputItem),
+                    Collections.emptyList(), 0);
+            CountableIngredient inputIngredient;
+            if (matchingRecipe != null) {
+                inputIngredient = matchingRecipe.getInputs().get(0);
+                recipeEUt = matchingRecipe.getEUt();
+                recipeDuration = matchingRecipe.getDuration();
+            } else
+                continue;
+
+            // Some error handling, probably unnecessary
+            if (inputIngredient == null)
+                throw new IllegalStateException(
+                        String.format("Recipe with null ingredient %s", matchingRecipe));
+
+            // Check to see if we have enough output slots
+            int itemsLeftUntilMax = (MAX_PROCESSES - currentItemsEngaged);
+            if (itemsLeftUntilMax >= inputIngredient.getCount()) {
+
+                // Make sure we don't go over maximum of 8 items per craft
+                int recipeMultiplier = Math.min((currentInputItem.getCount() / inputIngredient.getCount()),
+                        (itemsLeftUntilMax / inputIngredient.getCount()));
+
+                // Process to see how many slots the output will take
+                ArrayList<ItemStack> temp = new ArrayList<>(recipeOutputs);
+                computeOutputItemStacks(temp, matchingRecipe.getOutputs().get(0), recipeMultiplier);
+
+                // Check to see if we have output space available for the recipe
+                boolean canFitOutputs = InventoryUtils.simulateItemStackMerge(temp, this.getOutputInventory());
+                if (!canFitOutputs)
+                    break;
+
+                // Create output ItemStack list
+                temp.removeAll(recipeOutputs);
+                recipeOutputs.addAll(temp);
+
+                // Add ingredients to list of items to process
+                recipeInputs.add(new CountableIngredient(inputIngredient.getIngredient(),
+                        inputIngredient.getCount() * recipeMultiplier));
+
+                currentItemsEngaged += inputIngredient.getCount() * recipeMultiplier;
+            }
+        }
+
+        // No recipe was found
+        if (recipeInputs.isEmpty()) {
+            forceRecipeRecheck = true;
+            return null;
+        }
+
+        return recipeMap.recipeBuilder()
+                .inputsIngredients(recipeInputs)
+                .outputs(recipeOutputs)
+                .EUt(Math.min(32, (int)Math.ceil(recipeEUt * 1.33)))
+                .duration(Math.max(recipeDuration, (int)(recipeDuration * (100.0F / (100.0F + speedBonusPercent)) * 1.5)))
+                .build().getResult();
+    }
+
+    private void computeOutputItemStacks(Collection<ItemStack> recipeOutputs, ItemStack outputStack, int recipeAmount) {
+        if(!outputStack.isEmpty()) {
+            int finalAmount = outputStack.getCount() * recipeAmount;
+            int maxCount = outputStack.getMaxStackSize();
+            int numStacks = finalAmount / maxCount;
+            int remainder = finalAmount % maxCount;
+
+            for(int fullStacks = numStacks; fullStacks > 0; fullStacks--) {
+                ItemStack full = outputStack.copy();
+                full.setCount(maxCount);
+                recipeOutputs.add(full);
+            }
+
+            if (remainder > 0) {
+                ItemStack partial = outputStack.copy();
+                partial.setCount(remainder);
+                recipeOutputs.add(partial);
+            }
+        }
+    }
+}

--- a/src/main/java/gregicadditions/jei/GAMultiblockInfoCategory.java
+++ b/src/main/java/gregicadditions/jei/GAMultiblockInfoCategory.java
@@ -98,6 +98,7 @@ public class GAMultiblockInfoCategory implements IRecipeCategory<MultiblockInfoR
                 new MultiblockInfoRecipeWrapper(new PlasmaCondenserInfo()),
                 new MultiblockInfoRecipeWrapper(new LargePackagerInfo()),
                 new MultiblockInfoRecipeWrapper(new SteamGrinderInfo()),
+                new MultiblockInfoRecipeWrapper(new SteamOvenInfo()),
                 new MultiblockInfoRecipeWrapper(new CosmicRayDetectorInfo())
         ), "gregtech:multiblock_info");
     }

--- a/src/main/java/gregicadditions/jei/multi/simple/SteamOvenInfo.java
+++ b/src/main/java/gregicadditions/jei/multi/simple/SteamOvenInfo.java
@@ -3,6 +3,7 @@ package gregicadditions.jei.multi.simple;
 import com.google.common.collect.Lists;
 import gregicadditions.machines.GATileEntities;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
+import gregtech.common.blocks.BlockFireboxCasing;
 import gregtech.common.blocks.BlockMetalCasing;
 import gregtech.common.blocks.MetaBlocks;
 import gregtech.integration.jei.multiblock.MultiblockInfoPage;
@@ -14,11 +15,11 @@ import net.minecraft.util.EnumFacing;
 import java.util.ArrayList;
 import java.util.List;
 
-public class SteamGrinderInfo extends MultiblockInfoPage {
+public class SteamOvenInfo extends MultiblockInfoPage {
 
     @Override
     public MultiblockControllerBase getController() {
-        return GATileEntities.STEAM_GRINDER;
+        return GATileEntities.STEAM_OVEN;
     }
 
     @Override
@@ -26,11 +27,12 @@ public class SteamGrinderInfo extends MultiblockInfoPage {
         ArrayList<MultiblockShapeInfo> shapeInfo = new ArrayList<>();
 
         shapeInfo.add(MultiblockShapeInfo.builder()
-                .aisle("XXX", "IXX", "XXX")
-                .aisle("HXX", "S#X", "XXX")
-                .aisle("XXX", "OXX", "XXX")
-                .where('S', GATileEntities.STEAM_GRINDER, EnumFacing.WEST)
+                .aisle("FFF", "IXX", "###")
+                .aisle("HFF", "S#X", "XXX")
+                .aisle("FFF", "OXX", "###")
+                .where('S', GATileEntities.STEAM_OVEN, EnumFacing.WEST)
                 .where('X', MetaBlocks.METAL_CASING.getState(BlockMetalCasing.MetalCasingType.BRONZE_BRICKS))
+                .where('F', MetaBlocks.BOILER_FIREBOX_CASING.getState(BlockFireboxCasing.FireboxCasingType.BRONZE_FIREBOX))
                 .where('I', GATileEntities.STEAM_INPUT_BUS, EnumFacing.WEST)
                 .where('O', GATileEntities.STEAM_OUTPUT_BUS, EnumFacing.WEST)
                 .where('H', GATileEntities.STEAM_HATCH, EnumFacing.WEST)
@@ -42,6 +44,6 @@ public class SteamGrinderInfo extends MultiblockInfoPage {
 
     @Override
     public String[] getDescription() {
-        return new String[]{I18n.format("gtadditions.multiblock.steam_grinder.description")};
+        return new String[]{I18n.format("gtadditions.multiblock.steam_oven.description")};
     }
 }

--- a/src/main/java/gregicadditions/machines/GATileEntities.java
+++ b/src/main/java/gregicadditions/machines/GATileEntities.java
@@ -35,6 +35,7 @@ import gregicadditions.machines.multi.simple.*;
 import gregicadditions.machines.multi.steam.MetaTileEntitySteamGrinder;
 import gregicadditions.machines.multi.multiblockpart.MetaTileEntitySteamHatch;
 import gregicadditions.machines.multi.multiblockpart.MetaTileEntitySteamItemBus;
+import gregicadditions.machines.multi.steam.MetaTileEntitySteamOven;
 import gregicadditions.machines.overrides.*;
 import gregicadditions.recipes.GARecipeMaps;
 import gregtech.api.GTValues;
@@ -162,11 +163,12 @@ public class GATileEntities {
     //multiblock
     public static List<MetaTileEntityOutputFilteredHatch> OUTPUT_HATCH_FILTERED = new ArrayList<>();
 
-    // Steam Grinder
+    // Steam Multis
     public static MetaTileEntitySteamHatch STEAM_HATCH;
     public static MetaTileEntitySteamItemBus STEAM_INPUT_BUS;
     public static MetaTileEntitySteamItemBus STEAM_OUTPUT_BUS;
     public static MetaTileEntitySteamGrinder STEAM_GRINDER;
+    public static MetaTileEntitySteamOven STEAM_OVEN;
 
     //override from GTCE
     public static List<GAMetaTileEntityEnergyHatch> ENERGY_INPUT_HATCH_4_AMPS = new ArrayList<>();
@@ -1144,6 +1146,7 @@ public class GATileEntities {
         for (int i = 1; i < GAValues.V.length - 1; i++) { // minus 1 because we dont want MAX tier, plus one because we dont want ULV
             DIODES.add(GregTechAPI.registerMetaTileEntity(id++, new GAMetaTileEntityDiode(location("diode." + GAValues.VN[i].toLowerCase()), i)));
         }
+        STEAM_OVEN = GregTechAPI.registerMetaTileEntity(4197, new MetaTileEntitySteamOven(location("steam_oven")));
     }
 
     public static <T extends MetaTileEntity & ITieredMetaTileEntity> MTE<T> create(int id, T sampleMetaTileEntity) {

--- a/src/main/java/gregicadditions/machines/multi/steam/MetaTileEntitySteamGrinder.java
+++ b/src/main/java/gregicadditions/machines/multi/steam/MetaTileEntitySteamGrinder.java
@@ -3,38 +3,27 @@ package gregicadditions.machines.multi.steam;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
+import gregicadditions.GAConfig;
 import gregicadditions.capabilities.GregicAdditionsCapabilities;
 import gregicadditions.capabilities.impl.RecipeMapSteamMultiblockController;
-import gregicadditions.capabilities.impl.SteamMultiblockRecipeLogic;
-import gregtech.api.capability.IMultipleTankHandler;
-import gregtech.api.capability.impl.FluidTankList;
+import gregicadditions.capabilities.impl.SteamMultiWorkable;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.multiblock.BlockPattern;
 import gregtech.api.multiblock.FactoryBlockPattern;
-import gregtech.api.recipes.CountableIngredient;
-import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.render.ICubeRenderer;
 import gregtech.api.render.Textures;
-import gregtech.api.util.InventoryUtils;
 import gregtech.common.blocks.BlockMetalCasing;
 import gregtech.common.blocks.MetaBlocks;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.items.IItemHandlerModifiable;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 
 public class MetaTileEntitySteamGrinder extends RecipeMapSteamMultiblockController {
 
-    private static final double CONVERSION_RATE = 2.0; // Can add Config value for this if needed.
-                                                       // Currently is doing (1mb Steam -> 2EU) to be generous.
+    private static final double CONVERSION_RATE = GAConfig.SteamMultis.steamToEU;
 
     private static final MultiblockAbility<?>[] ALLOWED_ABILITIES = {
             GregicAdditionsCapabilities.STEAM_IMPORT_ITEMS, GregicAdditionsCapabilities.STEAM_EXPORT_ITEMS, GregicAdditionsCapabilities.STEAM
@@ -42,17 +31,12 @@ public class MetaTileEntitySteamGrinder extends RecipeMapSteamMultiblockControll
 
     public MetaTileEntitySteamGrinder(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId, RecipeMaps.MACERATOR_RECIPES, CONVERSION_RATE);
-        this.recipeMapWorkable = new SteamGrinderWorkable(this, CONVERSION_RATE);
+        this.recipeMapWorkable = new SteamMultiWorkable(this, CONVERSION_RATE, 8);
     }
 
     @Override
     public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder metaTileEntityHolder) {
         return new MetaTileEntitySteamGrinder(metaTileEntityId);
-    }
-
-    @Override
-    public void invalidateStructure() {
-        super.invalidateStructure();
     }
 
     @Override
@@ -84,136 +68,5 @@ public class MetaTileEntitySteamGrinder extends RecipeMapSteamMultiblockControll
         Textures.ROCK_CRUSHER_OVERLAY.renderSided(getFrontFacing(), renderState, translation, pipeline);
         if (recipeMapWorkable.isActive())
             Textures.ROCK_CRUSHER_ACTIVE_OVERLAY.renderSided(getFrontFacing(), renderState, translation, pipeline);
-    }
-
-    protected class SteamGrinderWorkable extends SteamMultiblockRecipeLogic {
-
-        public SteamGrinderWorkable(RecipeMapSteamMultiblockController tileEntity, double conversionRate) {
-            super(tileEntity, tileEntity.recipeMap, tileEntity.getSteamFluidTank(), conversionRate);
-        }
-
-        @Override
-        protected void trySearchNewRecipe() {
-            long maxVoltage = getMaxVoltage(); // Will always be LV voltage
-            Recipe currentRecipe = null;
-            IItemHandlerModifiable importInventory = getInputInventory();
-            boolean dirty = checkRecipeInputsDirty(importInventory, null);
-
-            if(dirty || forceRecipeRecheck) {
-                this.forceRecipeRecheck = false;
-
-                currentRecipe = findRecipe(maxVoltage, importInventory, null);
-                if (currentRecipe != null) {
-                    this.previousRecipe = currentRecipe;
-                }
-            } else if (previousRecipe != null && previousRecipe.matches(false, importInventory, new FluidTankList(false))) {
-                currentRecipe = previousRecipe;
-            }
-
-            if (currentRecipe != null && setupAndConsumeRecipeInputs(currentRecipe)) {
-                setupRecipe(currentRecipe);
-            }
-        }
-
-        @Override
-        protected Recipe findRecipe(long maxVoltage, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs) {
-            int currentItemsEngaged = 0;
-            final int maxItemsLimit = 8;
-            final ArrayList<CountableIngredient> recipeInputs = new ArrayList<>();
-            final ArrayList<ItemStack> recipeOutputs = new ArrayList<>();
-            int recipeEUt = 0;
-            int recipeDuration = 1;
-            float speedBonusPercent = 0.0F; // Currently unused
-
-            /* Iterate over input items looking for more items to process until we
-             * have touched every item, or are at maximum item capacity
-             */
-            for (int index = 0; index < inputs.getSlots() && currentItemsEngaged < maxItemsLimit; index ++) {
-                final ItemStack currentInputItem = inputs.getStackInSlot(index);
-
-                // Skip slot if empty
-                if (currentInputItem.isEmpty())
-                    continue;
-
-                // Check recipe for item in slot
-                Recipe matchingRecipe = recipeMap.findRecipe(maxVoltage,
-                        Collections.singletonList(currentInputItem),
-                        Collections.emptyList(), 0);
-                CountableIngredient inputIngredient;
-                if (matchingRecipe != null) {
-                    inputIngredient = matchingRecipe.getInputs().get(0);
-                    recipeEUt = matchingRecipe.getEUt();
-                    recipeDuration = matchingRecipe.getDuration();
-                } else
-                    continue;
-
-                // Some error handling, probably unnecessary
-                if (inputIngredient == null)
-                    throw new IllegalStateException(
-                            String.format("Recipe with null ingredient %s", matchingRecipe));
-
-                // Check to see if we have enough output slots
-                int itemsLeftUntilMax = (maxItemsLimit - currentItemsEngaged);
-                if (itemsLeftUntilMax >= inputIngredient.getCount()) {
-
-                    // Make sure we don't go over maximum of 8 items per craft
-                    int recipeMultiplier = Math.min((currentInputItem.getCount() / inputIngredient.getCount()),
-                                                    (itemsLeftUntilMax / inputIngredient.getCount()));
-
-                    // Process to see how many slots the output will take
-                    ArrayList<ItemStack> temp = new ArrayList<>(recipeOutputs);
-                    computeOutputItemStacks(temp, matchingRecipe.getOutputs().get(0), recipeMultiplier);
-
-                    // Check to see if we have output space available for the recipe
-                    boolean canFitOutputs = InventoryUtils.simulateItemStackMerge(temp, this.getOutputInventory());
-                    if (!canFitOutputs)
-                        break;
-
-                    // Create output ItemStack list
-                    temp.removeAll(recipeOutputs);
-                    recipeOutputs.addAll(temp);
-
-                    // Add ingredients to list of items to process
-                    recipeInputs.add(new CountableIngredient(inputIngredient.getIngredient(),
-                            inputIngredient.getCount() * recipeMultiplier));
-
-                    currentItemsEngaged += inputIngredient.getCount() * recipeMultiplier;
-                }
-            }
-
-            // No recipe was found
-            if (recipeInputs.isEmpty()) {
-                forceRecipeRecheck = true;
-                return null;
-            }
-
-            return recipeMap.recipeBuilder()
-                    .inputsIngredients(recipeInputs)
-                    .outputs(recipeOutputs)
-                    .EUt(Math.min(32, (int)Math.ceil(recipeEUt * 1.33)))
-                    .duration(Math.max(recipeDuration, (int)(recipeDuration * (100.0F / (100.0F + speedBonusPercent)) * 1.5)))
-                    .build().getResult();
-        }
-
-        private void computeOutputItemStacks(Collection<ItemStack> recipeOutputs, ItemStack outputStack, int recipeAmount) {
-            if(!outputStack.isEmpty()) {
-                int finalAmount = outputStack.getCount() * recipeAmount;
-                int maxCount = outputStack.getMaxStackSize();
-                int numStacks = finalAmount / maxCount;
-                int remainder = finalAmount % maxCount;
-
-                for(int fullStacks = numStacks; fullStacks > 0; fullStacks--) {
-                    ItemStack full = outputStack.copy();
-                    full.setCount(maxCount);
-                    recipeOutputs.add(full);
-                }
-
-                if (remainder > 0) {
-                    ItemStack partial = outputStack.copy();
-                    partial.setCount(remainder);
-                    recipeOutputs.add(partial);
-                }
-            }
-        }
     }
 }

--- a/src/main/java/gregicadditions/machines/multi/steam/MetaTileEntitySteamOven.java
+++ b/src/main/java/gregicadditions/machines/multi/steam/MetaTileEntitySteamOven.java
@@ -1,0 +1,164 @@
+package gregicadditions.machines.multi.steam;
+
+import codechicken.lib.render.CCRenderState;
+import codechicken.lib.render.pipeline.IVertexOperation;
+import codechicken.lib.vec.Matrix4;
+import gregicadditions.GAConfig;
+import gregicadditions.capabilities.GregicAdditionsCapabilities;
+import gregicadditions.capabilities.impl.RecipeMapSteamMultiblockController;
+import gregicadditions.capabilities.impl.SteamMultiWorkable;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.multiblock.IMultiblockPart;
+import gregtech.api.multiblock.BlockPattern;
+import gregtech.api.multiblock.FactoryBlockPattern;
+import gregtech.api.recipes.RecipeMaps;
+import gregtech.api.render.ICubeRenderer;
+import gregtech.api.render.Textures;
+import gregtech.api.util.GTUtility;
+import gregtech.common.blocks.BlockFireboxCasing;
+import gregtech.common.blocks.BlockMetalCasing;
+import gregtech.common.blocks.MetaBlocks;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
+
+public class MetaTileEntitySteamOven extends RecipeMapSteamMultiblockController {
+
+    private static final double CONVERSION_RATE = GAConfig.SteamMultis.steamToEU;
+    private boolean isActive;
+
+    public MetaTileEntitySteamOven(ResourceLocation metaTileEntityId) {
+        super(metaTileEntityId, RecipeMaps.FURNACE_RECIPES, CONVERSION_RATE);
+        this.recipeMapWorkable = new SteamMultiWorkable(this, CONVERSION_RATE, 8);
+    }
+
+    @Override
+    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+        return new MetaTileEntitySteamOven(metaTileEntityId);
+    }
+
+    private void setActive(boolean active) {
+        this.isActive = active;
+        if (!getWorld().isRemote) {
+            if (isStructureFormed()) {
+                replaceFireboxAsActive(active);
+            }
+            writeCustomData(100, buf -> buf.writeBoolean(isActive));
+            markDirty();
+        }
+    }
+
+    @Override
+    protected BlockPattern createStructurePattern() {
+        return FactoryBlockPattern.start()
+                .aisle("XXX", "CCC", "#C#")
+                .aisle("XXX", "C#C", "#C#")
+                .aisle("XXX", "CSC", "#C#")
+                .setAmountAtLeast('L', 6)
+                .setAmountAtMost('H', 1)
+                .where('S', selfPredicate())
+                .where('L', statePredicate(getCasingState()))
+                .where('H', abilityPartPredicate(GregicAdditionsCapabilities.STEAM))
+                .where('X', state -> statePredicate(GTUtility.getAllPropertyValues(getFireboxState(), BlockFireboxCasing.ACTIVE))
+                        .or(abilityPartPredicate(GregicAdditionsCapabilities.STEAM)).test(state))
+                .where('C', statePredicate(getCasingState()).or(abilityPartPredicate(
+                        GregicAdditionsCapabilities.STEAM_IMPORT_ITEMS, GregicAdditionsCapabilities.STEAM_EXPORT_ITEMS)))
+                .where('#', isAirPredicate())
+                .build();
+    }
+
+    public IBlockState getCasingState() {
+        return MetaBlocks.METAL_CASING.getState(BlockMetalCasing.MetalCasingType.BRONZE_BRICKS);
+    }
+
+    public IBlockState getFireboxState() {
+        return MetaBlocks.BOILER_FIREBOX_CASING.getState(BlockFireboxCasing.FireboxCasingType.BRONZE_FIREBOX);
+    }
+
+    private boolean isFireboxPart(IMultiblockPart sourcePart) {
+        return isStructureFormed() && (((MetaTileEntity) sourcePart).getPos().getY() < getPos().getY());
+    }
+
+    @Override
+    public ICubeRenderer getBaseTexture(IMultiblockPart sourcePart) {
+        if (sourcePart != null && isFireboxPart(sourcePart)) {
+            return isActive ? Textures.BRONZE_FIREBOX_ACTIVE : Textures.BRONZE_FIREBOX;
+        }
+        return Textures.BRONZE_PLATED_BRICKS;
+    }
+
+    @Override
+    public boolean shouldRenderOverlay(IMultiblockPart sourcePart) {
+        return sourcePart == null || !isFireboxPart(sourcePart);
+    }
+
+    private void replaceFireboxAsActive(boolean isActive) {
+        BlockPos centerPos = getPos().offset(getFrontFacing().getOpposite()).down();
+        for (int x = -1; x <= 1; x++) {
+            for (int z = -1; z <= 1; z++) {
+                BlockPos blockPos = centerPos.add(x, 0, z);
+                IBlockState blockState = getWorld().getBlockState(blockPos);
+                if (blockState.getBlock() instanceof BlockFireboxCasing) {
+                    blockState = blockState.withProperty(BlockFireboxCasing.ACTIVE, isActive);
+                    getWorld().setBlockState(blockPos, blockState);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void updateFormedValid() {
+        super.updateFormedValid();
+        if (isActive != recipeMapWorkable.isActive()) {
+            setActive(recipeMapWorkable.isActive());
+        }
+    }
+
+    @Override
+    public void onRemoval() {
+        super.onRemoval();
+        if (!getWorld().isRemote && isStructureFormed()) {
+            replaceFireboxAsActive(false);
+        }
+    }
+
+    @Override
+    public void invalidateStructure() {
+        super.invalidateStructure();
+        this.isActive = false;
+        replaceFireboxAsActive(false);
+    }
+
+    @Override
+    public int getLightValueForPart(IMultiblockPart sourcePart) {
+        return sourcePart == null ? 0 : (isActive ? 15 : 0);
+    }
+
+    @Override
+    public void writeInitialSyncData(PacketBuffer buf) {
+        super.writeInitialSyncData(buf);
+        buf.writeBoolean(isActive);
+    }
+
+    @Override
+    public void receiveInitialSyncData(PacketBuffer buf) {
+        super.receiveInitialSyncData(buf);
+        this.isActive = buf.readBoolean();
+    }
+
+    @Override
+    public void receiveCustomData(int dataId, PacketBuffer buf) {
+        super.receiveCustomData(dataId, buf);
+        if (dataId == 100) {
+            this.isActive = buf.readBoolean();
+        }
+    }
+
+    @Override
+    public void renderMetaTileEntity(CCRenderState renderState, Matrix4 translation, IVertexOperation[] pipeline) {
+        super.renderMetaTileEntity(renderState, translation, pipeline);
+        Textures.FURNACE_OVERLAY.render(renderState, translation, pipeline, getFrontFacing(), isActive);
+    }
+}

--- a/src/main/java/gregicadditions/recipes/MachineCraftingRecipes.java
+++ b/src/main/java/gregicadditions/recipes/MachineCraftingRecipes.java
@@ -924,6 +924,7 @@ public class MachineCraftingRecipes {
         ModHandler.addShapedRecipe("ga_steam_hatch", GATileEntities.STEAM_HATCH.getStackForm(), "BPB", "BTB", "BPB", 'B', new UnificationEntry(plate, Bronze), 'P', new UnificationEntry(pipeMedium, Bronze), 'T', MetaTileEntities.BRONZE_TANK.getStackForm());
         ModHandler.addShapedRecipe("ga_steam_input_bus", GATileEntities.STEAM_INPUT_BUS.getStackForm(), "BMB", "THT", "BMB", 'B', new UnificationEntry(plate, Bronze), 'M', new UnificationEntry(plate, Potin), 'T', new UnificationEntry(plate, Tin), 'H', Blocks.CHEST);
         ModHandler.addShapedRecipe("ga_steam_output_bus", GATileEntities.STEAM_OUTPUT_BUS.getStackForm(), "BTB", "MHM", "BTB", 'B', new UnificationEntry(plate, Bronze), 'M', new UnificationEntry(plate, Potin), 'T', new UnificationEntry(plate, Tin), 'H', Blocks.CHEST);
+        ModHandler.addShapedRecipe("ga_steam_oven", GATileEntities.STEAM_OVEN.getStackForm(), "CGC", "FMF", "CGC", 'F', MetaBlocks.BOILER_FIREBOX_CASING.getItemVariant(BlockFireboxCasing.FireboxCasingType.BRONZE_FIREBOX), 'C', MetaBlocks.METAL_CASING.getItemVariant(BlockMetalCasing.MetalCasingType.BRONZE_BRICKS), 'M', MetaTileEntities.STEAM_FURNACE_BRONZE.getStackForm(), 'G', new UnificationEntry(gear, Invar));
 
     }
 

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -3952,15 +3952,18 @@ fluid.krypton_difluoride=Krypton Difluoride
 fluid.high_energy_qgp=High Energy Quark-Gluon Plasma
 
 gtadditions.machine.steam_grinder.name=Steam Grinder
-gtadditions.machine.steam_grinder.tooltip=Processes up to 8 items per craft. Takes 1.5x base duration to process, not affected by number of items. Requires §eSteam Hatches and Busses
+gtadditions.machine.steam_grinder.tooltip=Macerates up to 8 items per craft. Takes 1.5x base duration to process, not affected by number of items. Requires §eSteam Hatches and Buses
 gtadditions.multiblock.steam_grinder.description=A Multiblock Macerator at the Steam Age. Requires at least 14 Bronze Casings to form. Cannot use normal Input/Output busses, nor Fluid Hatches other than the Steam Hatch.
-gtadditions.multiblock.steam_grinder.low_steam=Not enough Steam to run!
+gtadditions.multiblock.steam.low_steam=Not enough Steam to run!
 gtadditions.multiblock.steam.steam_stored=Steam: %s / %s mb
 gtadditions.machine.steam_hatch.name=Steam Hatch
 gtadditions.machine.steam.steam_hatch.tooltip=Accepted Fluid: §eSteam
 gtadditions.machine.steam_input_bus.name=Input Bus (Steam)
 gtadditions.machine.steam_output_bus.name=Output Bus (Steam)
 gtadditions.machine.steam_bus.tooltip=Does not work with non-steam multiblocks
+gtadditions.machine.steam_oven.name=Steam Oven
+gtadditions.machine.steam_oven.tooltip=Smelts up to 8 items per craft. Takes 1.5x base duration to process, not affected by number of items. Requires §eSteam Hatches and Buses
+gtadditions.multiblock.steam_oven.description=A Multi Smelter at the Steam Age. Requires at least 6 Bronze Casings to form. Cannot use normal Input/Output busses, nor Fluid Hatches other than the Steam Hatch. Steam Hatch must be on the bottom layer, no more than one.
 
 gtadditions.machine.diode.message=Max Amperage throughput: %s
 gtadditions.machine.diode.tooltip_general=A simple Diode that will allow Energy Flow in only one direction.


### PR DESCRIPTION
**What:**
This PR expands on the newly added Steam Multiblock parent classes, and adds a new multiblock inspired by the Railcraft Steam Oven, the brother to the Steam Grinder in 1.7.10 GT packs.

**How solved:**
The Steam Oven:
![Overview](https://user-images.githubusercontent.com/10861407/107112607-7c616f80-681e-11eb-9ae1-0969828e60c3.png)

It follows convention with the boilers, and lights up the Firebox Casings when active:
![active](https://user-images.githubusercontent.com/10861407/107112616-93a05d00-681e-11eb-8b25-72df5278a111.png)

I chose to use Firebox Casings for this since I wanted to make it a bit cheaper than the Steam Grinder, as Railcraft's was a 2x2x2 multiblock.

The recipe, which is also a little cheaper than the Steam Grinder, but not much (uses Invar for gears, like the MultiSmelter):
![recipe](https://user-images.githubusercontent.com/10861407/107112637-bc285700-681e-11eb-82d9-dd07dcfde0fb.PNG)

And lastly, the tooltip and JEI preview:
![tooltip](https://user-images.githubusercontent.com/10861407/107112628-adda3b00-681e-11eb-823c-32085ec8bab5.png)
![JEIPreview](https://user-images.githubusercontent.com/10861407/107112659-d7936200-681e-11eb-846e-bcfbf116e1c1.PNG)

**Outcome:**
Added Steam Oven

**Additional info:**
- I separated the nested `SteamGrinderWorkable` class and added a parameter for the number of items to process. I left it at 8 for this multiblock as well, but this makes it more flexible for the future. 
- I also added a new config entry for the `Steam -> EU` conversion rate for Steam Multiblocks. The standard rate used by single block Steam machines is 1:1, but for these, I decided to set their default to 2 Steam -> 1EU to balance it. It is still saving Steam overall compared to single block machines though.