### PR TITLE
Fix Some Outstanding Issues

### DIFF
--- a/src/main/java/gregicadditions/GAMaterials.java
+++ b/src/main/java/gregicadditions/GAMaterials.java
@@ -93,7 +93,7 @@ public class GAMaterials implements IMaterialHandler {
     public static final DustMaterial Ferrosilite = new DustMaterial(953, "ferrosilite", 5256470, MaterialIconSet.SAND, 1, ImmutableList.of(new MaterialStack(Iron, 1), new MaterialStack(Silicon, 1), new MaterialStack(Oxygen, 3)), 0);
     public static final DustMaterial Cryotheum = new DustMaterial(952, "cryotheum", 0x01F3F6, MaterialIconSet.SAND, 1, ImmutableList.of(), DISABLE_DECOMPOSITION | EXCLUDE_BLOCK_CRAFTING_RECIPES | SMELT_INTO_FLUID);
     public static final DustMaterial Blizz = new DustMaterial(951, "blizz", 0x01F3F6, MaterialIconSet.DULL, 1, ImmutableList.of(), NO_SMELTING | SMELT_INTO_FLUID | MORTAR_GRINDABLE | BURNING);
-    public static final DustMaterial Snow = new DustMaterial(950, "snow", 0xFFFFFF, MaterialIconSet.OPAL, 1, ImmutableList.of(), NO_SMELTING);
+    public static final DustMaterial Snow = new DustMaterial(950, "snow", 0xFFFFFF, MaterialIconSet.OPAL, 1, ImmutableList.of(), NO_SMELTING | EXCLUDE_BLOCK_CRAFTING_RECIPES);
     //    public static final FluidMaterial HighPressureSteam = new FluidMaterial(949, "high_pressure_steam", 0xFFFFFF, MaterialIconSet.GAS, of(new MaterialStack(Hydrogen, 2), new MaterialStack(Oxygen, 1)), NO_RECYCLING | GENERATE_FLUID_BLOCK | DISABLE_DECOMPOSITION).setFluidTemperature(1000);
     public static final FluidMaterial HighOctaneGasoline = new FluidMaterial(948, "high_octane", 0xC7860B, MaterialIconSet.FLUID, ImmutableList.of(), NO_RECYCLING | GENERATE_FLUID_BLOCK | DISABLE_DECOMPOSITION);
     public static final FluidMaterial Octane = new FluidMaterial(947, "octane", 0xCBCBCB, MaterialIconSet.FLUID, ImmutableList.of(), NO_RECYCLING | GENERATE_FLUID_BLOCK | DISABLE_DECOMPOSITION);

--- a/src/main/java/gregicadditions/recipes/GAMachineRecipeRemoval.java
+++ b/src/main/java/gregicadditions/recipes/GAMachineRecipeRemoval.java
@@ -290,8 +290,6 @@ public class GAMachineRecipeRemoval {
             }
         }
         recipes.forEach(recipe -> ASSEMBLER_RECIPES.removeRecipe(recipe));
-
-        removeRecipesByInputs(BLAST_RECIPES, OreDictUnifier.get(dust, Aluminium));
     }
 
     public static <R extends RecipeBuilder<R>> void removeRecipesByInputs(RecipeMap<R> map, ItemStack... itemInputs) {

--- a/src/main/java/gregicadditions/recipes/GAMachineRecipeRemoval.java
+++ b/src/main/java/gregicadditions/recipes/GAMachineRecipeRemoval.java
@@ -291,7 +291,7 @@ public class GAMachineRecipeRemoval {
         }
         recipes.forEach(recipe -> ASSEMBLER_RECIPES.removeRecipe(recipe));
 
-
+        removeRecipesByInputs(BLAST_RECIPES, OreDictUnifier.get(dust, Aluminium));
     }
 
     public static <R extends RecipeBuilder<R>> void removeRecipesByInputs(RecipeMap<R> map, ItemStack... itemInputs) {

--- a/src/main/java/gregicadditions/recipes/GARecipeAddition.java
+++ b/src/main/java/gregicadditions/recipes/GARecipeAddition.java
@@ -657,6 +657,7 @@ public class GARecipeAddition {
 
         COMPRESSOR_RECIPES.recipeBuilder().EUt(120).duration(300).input(ingot, Graphite).outputs(PYROLYTIC_CARBON.getStackForm()).buildAndRegister();
         BLAST_RECIPES.recipeBuilder().EUt(480).duration(3000).input(dust, Silicon).input(dust, Carbon).notConsumable(new IntCircuitIngredient(2)).fluidInputs(Argon.getFluid(1000)).outputs(SiliconCarbide.getItemStack(2)).blastFurnaceTemp(2500).buildAndRegister();
+        removeRecipesByInputs(BLAST_RECIPES, OreDictUnifier.get(dust, Aluminium));
         BLAST_RECIPES.recipeBuilder().EUt(120).duration(884).input(dust, Aluminium).notConsumable(new IntCircuitIngredient(1)).outputs(OreDictUnifier.get(ingot, Aluminium)).blastFurnaceTemp(1700).buildAndRegister();
     }
 

--- a/src/main/java/gregicadditions/recipes/GARecipeAddition.java
+++ b/src/main/java/gregicadditions/recipes/GARecipeAddition.java
@@ -657,6 +657,7 @@ public class GARecipeAddition {
 
         COMPRESSOR_RECIPES.recipeBuilder().EUt(120).duration(300).input(ingot, Graphite).outputs(PYROLYTIC_CARBON.getStackForm()).buildAndRegister();
         BLAST_RECIPES.recipeBuilder().EUt(480).duration(3000).input(dust, Silicon).input(dust, Carbon).notConsumable(new IntCircuitIngredient(2)).fluidInputs(Argon.getFluid(1000)).outputs(SiliconCarbide.getItemStack(2)).blastFurnaceTemp(2500).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().EUt(120).duration(884).input(dust, Aluminium).notConsumable(new IntCircuitIngredient(1)).outputs(OreDictUnifier.get(ingot, Aluminium)).blastFurnaceTemp(1700).buildAndRegister();
     }
 
 

--- a/src/main/java/gregicadditions/recipes/GARecipeAddition.java
+++ b/src/main/java/gregicadditions/recipes/GARecipeAddition.java
@@ -554,6 +554,18 @@ public class GARecipeAddition {
                 .outputs(OreDictUnifier.get(dust, EnderPearl, 10))
                 .buildAndRegister();
 
+        // Snow
+        FORGE_HAMMER_RECIPES.recipeBuilder().EUt(24).duration(50)
+                .input(block, Snow)
+                .outputs(OreDictUnifier.get(dust, Snow, 4))
+                .buildAndRegister();
+
+        COMPRESSOR_RECIPES.recipeBuilder().EUt(2).duration(200)
+                .input(dust, Snow, 4)
+                .outputs(OreDictUnifier.get(block, Snow, 4))
+                .buildAndRegister();
+
+
         ASSEMBLER_RECIPES.recipeBuilder().fluidInputs(HastelloyN.getFluid(144 * 4)).input(valueOf("gtMetalCasing"), Staballoy, 2).inputs(CountableIngredient.from(circuit, Tier.Extreme)).outputs(GAMetaBlocks.MUTLIBLOCK_CASING.getItemVariant(GAMultiblockCasing.CasingType.LARGE_ASSEMBLER, 2)).duration(600).EUt(8000).buildAndRegister();
         ASSEMBLER_RECIPES.recipeBuilder().EUt(240).duration(1200).input(plateDense, Lead, 4).fluidInputs(Oxygen.getFluid(16000)).input(OrePrefix.valueOf("gtMetalCasing"), StainlessSteel).outputs(GAMetaBlocks.CELL_CASING.getItemVariant(CellCasing.CellType.CELL_HV)).buildAndRegister();
         ASSEMBLER_RECIPES.recipeBuilder().EUt(960).duration(2400).input(plateDense, Titanium, 4).fluidInputs(Nitrogen.getFluid(16000)).inputs(GAMetaBlocks.CELL_CASING.getItemVariant(CellCasing.CellType.CELL_HV)).outputs(GAMetaBlocks.CELL_CASING.getItemVariant(CellCasing.CellType.CELL_EV)).buildAndRegister();

--- a/src/main/java/gregicadditions/recipes/RecipeHandler.java
+++ b/src/main/java/gregicadditions/recipes/RecipeHandler.java
@@ -462,16 +462,30 @@ public class RecipeHandler {
     }
 
     public static void registerLargeMixerRecipes() {
-        RecipeMaps.MIXER_RECIPES.getRecipeList().forEach(recipe ->
-                GARecipeMaps.LARGE_MIXER_RECIPES.recipeBuilder()
-                        .notConsumable(new IntCircuitIngredient(recipe.getInputs().size() + recipe.getFluidInputs().size()))
-                        .EUt(recipe.getEUt())
-                        .duration(recipe.getDuration())
-                        .fluidInputs(recipe.getFluidInputs())
-                        .inputsIngredients(recipe.getInputs())
-                        .outputs(recipe.getOutputs())
-                        .fluidOutputs(recipe.getFluidOutputs())
-                        .buildAndRegister());
+        RecipeMaps.MIXER_RECIPES.getRecipeList().forEach(recipe -> {
+            List<CountableIngredient> inputList = new ArrayList<>();
+            IntCircuitIngredient circuitIngredient = null;
+
+            for (CountableIngredient input : recipe.getInputs()) {
+                if (!(input.getIngredient() instanceof IntCircuitIngredient))
+                    inputList.add(input);
+                else
+                    circuitIngredient = (IntCircuitIngredient) input.getIngredient();
+            }
+
+            if (circuitIngredient == null)
+                circuitIngredient = new IntCircuitIngredient(inputList.size() + recipe.getFluidInputs().size());
+
+            GARecipeMaps.LARGE_MIXER_RECIPES.recipeBuilder()
+                    .notConsumable(circuitIngredient)
+                    .EUt(recipe.getEUt())
+                    .duration(recipe.getDuration())
+                    .fluidInputs(recipe.getFluidInputs())
+                    .inputsIngredients(inputList)
+                    .outputs(recipe.getOutputs())
+                    .fluidOutputs(recipe.getFluidOutputs())
+                    .buildAndRegister();
+        });
     }
 
     public static void registerLargeCentrifugeRecipes() {

--- a/src/main/resources/assets/gregtech/models/item/tools/bending_cylinder.json
+++ b/src/main/resources/assets/gregtech/models/item/tools/bending_cylinder.json
@@ -2,8 +2,8 @@
   "parent": "item/generated",
   "textures": {
     "layer0": "gregtech:items/void",
-    "layer1": "gregtech:items/void",
-    "layer2": "gregtech:items/tools/bending_cylinder",
+    "layer1": "gregtech:items/tools/bending_cylinder",
+    "layer2": "gregtech:items/void",
     "layer3": "gregtech:items/void"
   }
 }

--- a/src/main/resources/assets/gregtech/models/item/tools/bending_cylinder_small.json
+++ b/src/main/resources/assets/gregtech/models/item/tools/bending_cylinder_small.json
@@ -2,8 +2,8 @@
   "parent": "item/generated",
   "textures": {
     "layer0": "gregtech:items/void",
-    "layer1": "gregtech:items/void",
-    "layer2": "gregtech:items/tools/bending_cylinder_small",
+    "layer1": "gregtech:items/tools/bending_cylinder_small",
+    "layer2": "gregtech:items/void",
     "layer3": "gregtech:items/void"
   }
 }


### PR DESCRIPTION
- Fixes #315:
See https://github.com/Shadows-of-Fire/Shadows-of-Greg/pull/106 for a description of the fix for this issue.

- Fixes #168:
This issue occurred for any Mixer recipe that had an integrated circuit, but there only happen to be two so far. I added a section of code in the Large Mixer recipe builder to iterate over all inputs, and if it finds a circuit, it removes it from the input list. I also had to save that circuit value, and use it instead of the default logic of `total input items/fluids count` to avoid a conflict.

- Fixes #366:
I added a circuit of configuration 1 to the standard Aluminium EBF recipe. The EUt, duration, and blastTemp are all identical.

- Fixes #271:
I added the flag `EXCLUDE_BLOCK_CRAFTING_RECIPES` and added each recipe manually to use 4 instead of 9.

Each issue I fixed has a different commit, so if you want to see the individual changes for each issue, you can view that commit's changes.