### PR TITLE
Generify Tuple

### DIFF
--- a/src/main/java/gregicadditions/machines/multi/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/multi/TileEntityProcessingArray.java
@@ -6,7 +6,7 @@ import gregicadditions.GAValues;
 import gregicadditions.capabilities.impl.ControllerSlotMultiblockRecipeLogic;
 import gregicadditions.capabilities.impl.RecipeMapMultiblockWithSlotController;
 import gregicadditions.item.GAMetaBlocks;
-import gregicadditions.machines.multi.simple.Tuple;
+import gregicadditions.utils.Tuple;
 import gregicadditions.recipes.GARecipeMaps;
 import gregicadditions.utils.GALog;
 import gregtech.api.GregTechAPI;

--- a/src/main/java/gregicadditions/machines/multi/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/multi/TileEntityProcessingArray.java
@@ -152,13 +152,13 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockWithSlotContro
             recipeMapName = recipeMap.getLocalizedName();
 
             List<IItemHandlerModifiable> itemInputs = ((TileEntityProcessingArray) this.getMetaTileEntity()).getAbilities(MultiblockAbility.IMPORT_ITEMS);
-            Tuple recipePerInput = itemInputs.stream()
-                    .map(iItemHandlerModifiable -> new Tuple(recipeMap.findRecipe(maxVoltage, iItemHandlerModifiable, fluidInputs, 0), iItemHandlerModifiable))
-                    .filter(tuple -> tuple.getRecipe() != null)
-                    .findFirst().orElse(new Tuple(recipeMap.findRecipe(voltageTier, inputs, fluidInputs, this.getMinTankCapacity(this.getOutputTank())), inputs));
+            Tuple<Recipe, IItemHandlerModifiable> recipePerInput = itemInputs.stream()
+                    .map(iItemHandlerModifiable -> new Tuple<>(recipeMap.findRecipe(maxVoltage, iItemHandlerModifiable, fluidInputs, 0), iItemHandlerModifiable))
+                    .filter(tuple -> tuple.getKey() != null)
+                    .findFirst().orElse(new Tuple<>(recipeM.findRecipe(machineTierVoltage, inputs, fluidInputs, this.getMinTankCapacity(this.getOutputTank())), inputs));
 
 
-            if (recipePerInput.getRecipe() == null) {
+            if (recipePerInput.getKey() == null) {
                 return null;
             }
 
@@ -166,18 +166,18 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockWithSlotContro
             int minMultiplier = Integer.MAX_VALUE;
 
             Set<ItemStack> countIngredients = new HashSet<>();
-            if (recipePerInput.getRecipe().getInputs().size() != 0) {
+            if (recipePerInput.getKey().getInputs().size() != 0) {
 
-                this.findIngredients(countIngredients, recipePerInput.getInput());
-                minMultiplier = Math.min(minMultiplier, this.getMinRatioItem(countIngredients, recipePerInput.getRecipe(), recipePerInput.getInput(), numberOfMachines));
+                this.findIngredients(countIngredients, recipePerInput.getValue());
+                minMultiplier = Math.min(minMultiplier, this.getMinRatioItem(countIngredients, recipePerInput.getKey(), recipePerInput.getValue(), numberOfMachines));
 
             }
 
             Map<String, Integer> countFluid = new HashMap<>();
-            if (recipePerInput.getRecipe().getFluidInputs().size() != 0) {
+            if (recipePerInput.getKey().getFluidInputs().size() != 0) {
 
                 this.findFluid(countFluid, fluidInputs);
-                minMultiplier = Math.min(minMultiplier, this.getMinRatioFluid(countFluid, recipePerInput.getRecipe(), numberOfMachines));
+                minMultiplier = Math.min(minMultiplier, this.getMinRatioFluid(countFluid, recipePerInput.getKey(), numberOfMachines));
             }
 
             if (minMultiplier == Integer.MAX_VALUE) {
@@ -191,17 +191,18 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockWithSlotContro
             List<FluidStack> newFluidInputs = new ArrayList<>();
             List<ItemStack> outputI = new ArrayList<>();
             List<FluidStack> outputF = new ArrayList<>();
-            this.multiplyInputsAndOutputs(newRecipeInputs, newFluidInputs, outputI, outputF, recipePerInput.getRecipe(), numberOfOperations);
+            this.multiplyInputsAndOutputs(newRecipeInputs, newFluidInputs, outputI, outputF, recipePerInput.getKey(), numberOfOperations);
 
             RecipeBuilder<?> newRecipe = recipeMap.recipeBuilder()
                     .inputsIngredients(newRecipeInputs)
                     .fluidInputs(newFluidInputs)
                     .outputs(outputI)
                     .fluidOutputs(outputF)
-                    .EUt(recipePerInput.getRecipe().getEUt())
-                    .duration(recipePerInput.getRecipe().getDuration());
+                    .EUt(recipePerInput.getKey().getEUt())
+                    .duration(recipePerInput.getKey().getDuration());
 
-            copyChancedItemOutputs(newRecipe, recipePerInput.getRecipe(), numberOfOperations);
+            copyChancedItemOutputs(newRecipe, recipePerInput.getKey(), numberOfOperations);
+            newRecipe.notConsumable(machineItemStack);
 
             return newRecipe.build().getResult();
         }

--- a/src/main/java/gregicadditions/machines/multi/simple/LargeSimpleRecipeMapMultiblockController.java
+++ b/src/main/java/gregicadditions/machines/multi/simple/LargeSimpleRecipeMapMultiblockController.java
@@ -5,6 +5,7 @@ import gregicadditions.capabilities.impl.GAMultiblockRecipeLogic;
 import gregicadditions.capabilities.impl.GARecipeMapMultiblockController;
 import gregicadditions.item.components.*;
 import gregicadditions.utils.GALog;
+import gregicadditions.utils.Tuple;
 import gregtech.api.capability.IMultipleTankHandler;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;

--- a/src/main/java/gregicadditions/machines/multi/simple/LargeSimpleRecipeMapMultiblockController.java
+++ b/src/main/java/gregicadditions/machines/multi/simple/LargeSimpleRecipeMapMultiblockController.java
@@ -288,16 +288,16 @@ abstract public class LargeSimpleRecipeMapMultiblockController extends GARecipeM
         protected Recipe findRecipe(long maxVoltage, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs) {
             List<IItemHandlerModifiable> itemInputs = ((RecipeMapMultiblockController) this.getMetaTileEntity()).getAbilities(MultiblockAbility.IMPORT_ITEMS);
 
-            Tuple recipePerInput = itemInputs.stream()
-                    .map(iItemHandlerModifiable -> new Tuple(recipeMap.findRecipe(maxVoltage, iItemHandlerModifiable, fluidInputs, 0), iItemHandlerModifiable))
-                    .filter(tuple -> tuple.getRecipe() != null)
-                    .findFirst().orElse(new Tuple(recipeMap.findRecipe(maxVoltage, inputs, fluidInputs, 0), inputs));
+            Tuple<Recipe, IItemHandlerModifiable> recipePerInput = itemInputs.stream()
+                    .map(iItemHandlerModifiable -> new Tuple<>(recipeMap.findRecipe(maxVoltage, iItemHandlerModifiable, fluidInputs, 0), iItemHandlerModifiable))
+                    .filter(tuple -> tuple.getKey() != null)
+                    .findFirst().orElse(new Tuple<>(recipeMap.findRecipe(maxVoltage, inputs, fluidInputs, 0), inputs));
 
-            if (recipePerInput.getRecipe() == null) {
+            if (recipePerInput.getKey() == null) {
                 return null;
             }
 
-            return createRecipe(maxVoltage, recipePerInput.getInput(), fluidInputs, recipePerInput.getRecipe());
+            return createRecipe(maxVoltage, recipePerInput.getValue(), fluidInputs, recipePerInput.getKey());
 
 
         }

--- a/src/main/java/gregicadditions/machines/multi/simple/Tuple.java
+++ b/src/main/java/gregicadditions/machines/multi/simple/Tuple.java
@@ -1,22 +1,20 @@
 package gregicadditions.machines.multi.simple;
 
-import gregtech.api.recipes.Recipe;
-import net.minecraftforge.items.IItemHandlerModifiable;
+public class Tuple<K, V> {
+    private final K key;
+    private final V value;
 
-public class Tuple {
-    private final Recipe recipe;
-    private final IItemHandlerModifiable input;
-
-    public Tuple(Recipe recipe, IItemHandlerModifiable input) {
-        this.recipe = recipe;
-        this.input = input;
+    public Tuple(K key, V value) {
+        this.key = key;
+        this.value = value;
     }
 
-    public Recipe getRecipe() {
-        return recipe;
+    public K getKey() {
+        return key;
     }
 
-    public IItemHandlerModifiable getInput() {
-        return input;
+    public V getValue() {
+        return value;
     }
 }
+// Recipe, IItemHandlerModifiable

--- a/src/main/java/gregicadditions/utils/Tuple.java
+++ b/src/main/java/gregicadditions/utils/Tuple.java
@@ -1,4 +1,4 @@
-package gregicadditions.machines.multi.simple;
+package gregicadditions.utils;
 
 public class Tuple<K, V> {
     private final K key;
@@ -17,4 +17,3 @@ public class Tuple<K, V> {
         return value;
     }
 }
-// Recipe, IItemHandlerModifiable

--- a/src/main/java/gregicadditions/utils/Tuple.java
+++ b/src/main/java/gregicadditions/utils/Tuple.java
@@ -16,4 +16,12 @@ public class Tuple<K, V> {
     public V getValue() {
         return value;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof Tuple))
+            return false;
+        Tuple<?, ?> tuple = (Tuple<?, ?>) obj;
+        return tuple.key.equals(key) && tuple.value.equals(value);
+    }
 }


### PR DESCRIPTION
The `Tuple` class (used currently just for a couple Large Multis) is a useful Object to have, and others can potentially use it to help write more organized code. All this PR does is make it generic, add an `equals()` override, and move it to `/util`