### PR TITLE
Fix Multiblock Preview Page

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     deobfCompile "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.20.554"
     deobfCompile "mezz.jei:jei_1.12.2:+"
     deobfCompile "net.sengir.forestry:forestry_1.12.2:5.8.2.387"
-    deobfCompile "gregtechce:gregtech:1.12.2:1.11.3.640"
+    deobfCompile "gregtechce:gregtech:1.12.2:1.12.0.662"
     deobfCompile "codechicken:ChickenASM:1.12-1.0.2.9"
     deobfCompile "codechicken-lib-1-8:CodeChickenLib-1.12.2:3.2.3.358:universal"
     deobfCompile "forge-multipart-cbe:ForgeMultipart-1.12.2:2.6.2.83:universal"

--- a/src/main/java/gregicadditions/jei/GAMultiblockInfoCategory.java
+++ b/src/main/java/gregicadditions/jei/GAMultiblockInfoCategory.java
@@ -16,6 +16,7 @@ import gregicadditions.jei.multi.simple.*;
 import gregicadditions.machines.GATileEntities;
 import gregtech.integration.jei.multiblock.MultiblockInfoRecipeWrapper;
 import gregtech.integration.jei.multiblock.infos.LargeTurbineInfo;
+import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.IJeiHelpers;
 import mezz.jei.api.IModRegistry;
 import mezz.jei.api.gui.IDrawable;
@@ -27,9 +28,11 @@ import net.minecraft.client.resources.I18n;
 
 public class GAMultiblockInfoCategory implements IRecipeCategory<MultiblockInfoRecipeWrapper> {
     private final IDrawable background;
+    private final IGuiHelper guiHelper;
 
     public GAMultiblockInfoCategory(IJeiHelpers helpers) {
-        this.background = helpers.getGuiHelper().createBlankDrawable(176, 166);
+        this.guiHelper = helpers.getGuiHelper();
+        this.background = guiHelper.createBlankDrawable(176, 166);
     }
 
     public static void registerRecipes(IModRegistry registry) {
@@ -126,6 +129,6 @@ public class GAMultiblockInfoCategory implements IRecipeCategory<MultiblockInfoR
 
     @Override
     public void setRecipe(IRecipeLayout recipeLayout, MultiblockInfoRecipeWrapper recipeWrapper, IIngredients ingredients) {
-        recipeWrapper.setRecipeLayout((RecipeLayout) recipeLayout);
+        recipeWrapper.setRecipeLayout((RecipeLayout) recipeLayout, guiHelper);
     }
 }

--- a/src/main/java/gregicadditions/jei/LargeMultiblockInfoRecipeWrapper.java
+++ b/src/main/java/gregicadditions/jei/LargeMultiblockInfoRecipeWrapper.java
@@ -2,6 +2,7 @@ package gregicadditions.jei;
 
 import gregtech.integration.jei.multiblock.MultiblockInfoPage;
 import gregtech.integration.jei.multiblock.MultiblockInfoRecipeWrapper;
+import mezz.jei.api.IGuiHelper;
 import mezz.jei.gui.recipes.RecipeLayout;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 
@@ -12,8 +13,8 @@ public class LargeMultiblockInfoRecipeWrapper extends MultiblockInfoRecipeWrappe
     }
 
     @Override
-    public void setRecipeLayout(RecipeLayout layout) {
-        super.setRecipeLayout(layout);
+    public void setRecipeLayout(RecipeLayout layout, IGuiHelper guiHelper) {
+        super.setRecipeLayout(layout, guiHelper);
         ObfuscationReflectionHelper.setPrivateValue(MultiblockInfoRecipeWrapper.class, this, 0.3f, "zoom");
     }
 }


### PR DESCRIPTION
This PR fixes our multiblock previews when GTCE version 1.12.0+ is included. There were some changes to the multiblock page methods that required us to pass in additional parameters.

Included in this PR is an update to the `build.gradle` to update our dependency to GTCE 1.12.0.662