### PR TITLE
Fix SimpleDusts missing their tooltips

### DIFF
--- a/src/main/java/gregicadditions/ClientProxy.java
+++ b/src/main/java/gregicadditions/ClientProxy.java
@@ -1,23 +1,30 @@
 package gregicadditions;
 
+import com.mojang.realmsclient.gui.ChatFormatting;
 import gregicadditions.blocks.GABlockOre;
 import gregicadditions.blocks.GAMetalCasing;
 import gregicadditions.input.Keybinds;
+import gregicadditions.item.GADustItem;
 import gregicadditions.item.GAMetaBlocks;
+import gregicadditions.materials.SimpleDustMaterial;
 import gregicadditions.renderer.OpticalFiberRenderer;
+import gregtech.api.unification.OreDictUnifier;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.color.IBlockColor;
 import net.minecraft.client.renderer.color.IItemColor;
 import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.client.event.ModelRegistryEvent;
+import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 import java.io.IOException;
+import java.util.Optional;
 
 @SideOnly(Side.CLIENT)
 @Mod.EventBusSubscriber(Side.CLIENT)
@@ -57,5 +64,22 @@ public class ClientProxy extends CommonProxy {
     public static void registerModels(ModelRegistryEvent event) {
         GAMetaBlocks.registerStateMappers();
         GAMetaBlocks.registerItemModels();
+    }
+
+    @SubscribeEvent
+    public static void addMaterialFormulaHandler(ItemTooltipEvent event) {
+        ItemStack itemStack = event.getItemStack();
+        if (!(itemStack.getItem() instanceof ItemBlock)) {
+            Optional<String> oreDictName = OreDictUnifier.getOreDictionaryNames(itemStack).stream().findFirst();
+            if (oreDictName.isPresent() && GADustItem.oreDictToSimpleDust.containsKey(oreDictName.get())) {
+                SimpleDustMaterial material = SimpleDustMaterial.GA_DUSTS.get((short) itemStack.getItemDamage());
+                if (material != null) {
+                    String formula = material.chemicalFormula;
+                    if (formula != null && !formula.isEmpty() && event.getToolTip().size() == 0) {
+                        event.getToolTip().add(1, ChatFormatting.GRAY.toString() + material.chemicalFormula);
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
As simple as the title. I added a method to `ClientProxy` to listen for a `ItemTooltipEvent` and add the tooltip there if it is a SimpleDust. A random example of one of them with a tooltip:
![image](https://user-images.githubusercontent.com/10861407/109628246-24a9e180-7b08-11eb-97dc-2e4e760beaf7.png)
