### PR TITLE
Switch to MavenCentral from JCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         maven { url = "http://files.minecraftforge.net/maven" }
     }
     dependencies {


### PR DESCRIPTION
The JCenter maven repository has been confirmed to be [shutting down](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) in the near future. This PR simply transitions us from using JCenter to pull from maven repositories to using MavenCentral. Functionality is identical, but will keep our projects from mysteriously breaking in the near future.


