### PR TITLE
Add Fluid Tooltips

### DIFF
--- a/src/main/java/gregicadditions/ClientProxy.java
+++ b/src/main/java/gregicadditions/ClientProxy.java
@@ -1,5 +1,6 @@
 package gregicadditions;
 
+import codechicken.lib.util.ItemNBTUtils;
 import com.mojang.realmsclient.gui.ChatFormatting;
 import gregicadditions.blocks.GABlockOre;
 import gregicadditions.blocks.GAMetalCasing;
@@ -7,6 +8,7 @@ import gregicadditions.input.Keybinds;
 import gregicadditions.item.GADustItem;
 import gregicadditions.item.GAMetaBlocks;
 import gregicadditions.materials.SimpleDustMaterial;
+import gregicadditions.materials.SimpleFluidMaterial;
 import gregicadditions.renderer.OpticalFiberRenderer;
 import gregtech.api.unification.OreDictUnifier;
 import net.minecraft.block.state.IBlockState;
@@ -78,6 +80,18 @@ public class ClientProxy extends CommonProxy {
                     if (formula != null && !formula.isEmpty() && event.getToolTip().size() == 0) {
                         event.getToolTip().add(1, ChatFormatting.GRAY.toString() + material.chemicalFormula);
                     }
+                }
+            }
+        }
+
+        if (ItemNBTUtils.hasTag(itemStack)) {
+
+            // Vanilla bucket
+            String fluidName = ItemNBTUtils.getString(itemStack, "FluidName");
+            if (fluidName != null) {
+                SimpleFluidMaterial material = SimpleFluidMaterial.GA_FLUIDS.get(fluidName);
+                if (material != null && material.chemicalFormula != null && !material.chemicalFormula.isEmpty()) {
+                    event.getToolTip().add(1, ChatFormatting.GRAY + material.chemicalFormula);
                 }
             }
         }

--- a/src/main/java/gregicadditions/coremod/GAClassTransformer.java
+++ b/src/main/java/gregicadditions/coremod/GAClassTransformer.java
@@ -38,6 +38,9 @@ public class GAClassTransformer implements IClassTransformer {
             case "gregtech.api.metatileentity.MetaTileEntity":
                 tform = MetaTileEntityTransformer.INSTANCE;
                 break;
+            case "gregtech.api.util.GTUtility":
+                tform = GTUtilityTransformer.INSTANCE;
+                break;
             default:
                 return basicClass;
         }
@@ -58,11 +61,15 @@ public class GAClassTransformer implements IClassTransformer {
         transformClass(byte[] code) {
             ClassReader reader = new ClassReader(code);
             ClassWriter writer = new ClassWriter(reader, getWriteFlags());
-            reader.accept(getClassMapper(writer), 0);
+            reader.accept(getClassMapper(writer), getAcceptFlags());
             return writer.toByteArray();
         }
 
         protected int getWriteFlags() {
+            return 0;
+        }
+
+        protected int getAcceptFlags() {
             return 0;
         }
 

--- a/src/main/java/gregicadditions/coremod/GAClassTransformer.java
+++ b/src/main/java/gregicadditions/coremod/GAClassTransformer.java
@@ -61,15 +61,11 @@ public class GAClassTransformer implements IClassTransformer {
         transformClass(byte[] code) {
             ClassReader reader = new ClassReader(code);
             ClassWriter writer = new ClassWriter(reader, getWriteFlags());
-            reader.accept(getClassMapper(writer), getAcceptFlags());
+            reader.accept(getClassMapper(writer), 0);
             return writer.toByteArray();
         }
 
         protected int getWriteFlags() {
-            return 0;
-        }
-
-        protected int getAcceptFlags() {
             return 0;
         }
 

--- a/src/main/java/gregicadditions/coremod/hooks/GregTechCEHooks.java
+++ b/src/main/java/gregicadditions/coremod/hooks/GregTechCEHooks.java
@@ -3,6 +3,7 @@ package gregicadditions.coremod.hooks;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.vec.Matrix4;
 import gregicadditions.covers.CoverDigitalInterface;
+import gregicadditions.materials.SimpleFluidMaterial;
 import gregtech.api.capability.impl.EnergyContainerBatteryBuffer;
 import gregtech.api.capability.impl.EnergyContainerHandler;
 import gregtech.api.cover.CoverBehavior;
@@ -15,6 +16,7 @@ import gregtech.common.items.behaviors.CoverPlaceBehavior;
 import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
+import net.minecraftforge.fluids.FluidStack;
 
 public class GregTechCEHooks {
 
@@ -117,5 +119,18 @@ public class GregTechCEHooks {
             return true;
         }
         return coverable.canPlaceCoverOnSide(side);
+    }
+
+    //origin: gregtech/api/util/GTUtility.formulaHook(FluidStack fluidStack)
+    public static void getSimpleFluidTooltip(FluidStack fluidStack, StringBuilder formula) {
+        if (fluidStack != null) {
+            String[] materialArray = fluidStack.getUnlocalizedName().split("\\.");
+            if (materialArray.length >= 2 && materialArray[0].equals("fluid")) {
+                SimpleFluidMaterial material = SimpleFluidMaterial.GA_FLUIDS.get(materialArray[1]);
+                if (material != null && material.chemicalFormula != null && !material.chemicalFormula.isEmpty()) {
+                    formula.append(material.chemicalFormula);
+                }
+            }
+        }
     }
 }

--- a/src/main/java/gregicadditions/coremod/transform/GTUtilityTransformer.java
+++ b/src/main/java/gregicadditions/coremod/transform/GTUtilityTransformer.java
@@ -1,0 +1,57 @@
+package gregicadditions.coremod.transform;
+
+import gregicadditions.coremod.GAClassTransformer;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class GTUtilityTransformer extends GAClassTransformer.ClassMapper {
+
+    public static final GTUtilityTransformer INSTANCE = new GTUtilityTransformer();
+
+    private GTUtilityTransformer() {
+    }
+
+    @Override
+    protected ClassVisitor getClassMapper(ClassVisitor cv) {
+        return new TransformerGTUtility(Opcodes.ASM5, cv);
+    }
+
+    private static class TransformerGTUtility extends ClassVisitor implements Opcodes {
+
+        TransformerGTUtility(int api, ClassVisitor cv) {
+            super(api, cv);
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+            if (name.equals("formulaHook")) {
+                return new TransformFormulaHook(api, super.visitMethod(access, name, desc, signature, exceptions));
+            }
+            return super.visitMethod(access, name, desc, signature, exceptions);
+        }
+    }
+
+    private static class TransformFormulaHook extends MethodVisitor implements Opcodes {
+
+        private static final String INSERT_CLASS_NAME = "gregicadditions/coremod/hooks/GregTechCEHooks";
+        private static final String INSERT_METHOD_SIGNATURE = "(Lnet/minecraftforge/fluids/FluidStack;Ljava/lang/StringBuilder;)V";
+        private static final String INSERT_METHOD_NAME = "getSimpleFluidTooltip";
+
+        TransformFormulaHook(int api, MethodVisitor mv) {
+            super(api, mv);
+        }
+
+        @Override
+        public void visitCode() {
+
+            mv.visitVarInsn(ALOAD, 0); // FluidStack
+            mv.visitVarInsn(ALOAD, 1); // StringBuilder
+
+            // statically call getSimpleFluidTooltip(FluidStack, StringBuilder)
+            mv.visitMethodInsn(INVOKESTATIC, INSERT_CLASS_NAME, INSERT_METHOD_NAME, INSERT_METHOD_SIGNATURE, false);
+
+            mv.visitCode();
+        }
+    }
+}

--- a/src/main/java/gregicadditions/fluid/GAMetaFluids.java
+++ b/src/main/java/gregicadditions/fluid/GAMetaFluids.java
@@ -45,7 +45,7 @@ public class GAMetaFluids {
             isotopeMaterial.hexafluorideSteamCracked = MetaFluids.registerFluid(ingotMaterial, MetaFluids.FluidType.valueOf("HEXAFLUORIDE_STEAM_CRACKED"), 300);
         });
 
-        for (SimpleFluidMaterial fluidMat : SimpleFluidMaterial.GA_FLUIDS) {
+        for (SimpleFluidMaterial fluidMat : SimpleFluidMaterial.GA_FLUIDS.values()) {
             Fluid fluid = new Fluid(fluidMat.name, MetaFluids.AUTO_GENERATED_FLUID_TEXTURE, MetaFluids.AUTO_GENERATED_FLUID_TEXTURE, fluidMat.rgb);
             fluid.setTemperature(fluidMat.temperature);
             if (!FluidRegistry.isFluidRegistered(fluid.getName())) {

--- a/src/main/java/gregicadditions/materials/SimpleFluidMaterial.java
+++ b/src/main/java/gregicadditions/materials/SimpleFluidMaterial.java
@@ -1,35 +1,58 @@
 package gregicadditions.materials;
 
+import com.google.common.collect.ImmutableList;
+import gregtech.api.unification.stack.MaterialStack;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class SimpleFluidMaterial extends SimpleMaterial {
 
-    public static List<SimpleFluidMaterial> GA_FLUIDS = new ArrayList<>();
-
+    public static Map<String, SimpleFluidMaterial> GA_FLUIDS = new HashMap<>();
     public int temperature;
     public Fluid fluid;
     public boolean hasPlasma;
     public Fluid plasma;
+    public final ImmutableList<MaterialStack> materialComponents;
+    public String chemicalFormula;
 
 
     public SimpleFluidMaterial(String name, int rgb) {
-        this(name, rgb, 300, false);
+        this(name, rgb, 300, false, null);
     }
 
-    public SimpleFluidMaterial(String name, int rgb, int temperature) { this(name, rgb, temperature, false); }
+    public SimpleFluidMaterial(String name, int rgb, ImmutableList<MaterialStack> materialComponents) {
+        this(name, rgb, 300, false, materialComponents);
+    }
 
-    public SimpleFluidMaterial(String name, int rgb, boolean hasPlasma) { this(name, rgb, 300, hasPlasma); }
+    public SimpleFluidMaterial(String name, int rgb, int temperature) {
+        this(name, rgb, temperature, false, null);
+    }
 
-    public SimpleFluidMaterial(String name, int rgb, int temperature, boolean hasPlasma) {
+    public SimpleFluidMaterial(String name, int rgb, int temperature, ImmutableList<MaterialStack> materialComponents) {
+        this(name, rgb, temperature, false, materialComponents);
+    }
+
+    public SimpleFluidMaterial(String name, int rgb, boolean hasPlasma) {
+        this(name, rgb, 300, hasPlasma, null);
+    }
+
+    public SimpleFluidMaterial(String name, int rgb, boolean hasPlasma, ImmutableList<MaterialStack> materialComponents) {
+        this(name, rgb, 300, hasPlasma, materialComponents);
+    }
+
+    public SimpleFluidMaterial(String name, int rgb, int temperature, boolean hasPlasma, ImmutableList<MaterialStack> materialComponents) {
         this.name = name;
         this.rgb = rgb;
         this.temperature = temperature;
         this.hasPlasma = hasPlasma;
-        GA_FLUIDS.add(this);
+        this.materialComponents = materialComponents;
+        this.chemicalFormula = calculateChemicalFormula();
+        GA_FLUIDS.put(name, this);
     }
 
     public FluidStack getFluid(int amount) {
@@ -37,5 +60,15 @@ public class SimpleFluidMaterial extends SimpleMaterial {
     }
 
     public FluidStack getPlasma(int amount) { return hasPlasma ? new FluidStack(plasma, amount) : null; }
+
+    private String calculateChemicalFormula() {
+        if (materialComponents != null && !materialComponents.isEmpty()) {
+            StringBuilder components = new StringBuilder();
+            for (MaterialStack component : materialComponents)
+                components.append(component.toString());
+            return components.toString();
+        }
+        return "";
+    }
 
 }


### PR DESCRIPTION
Following the PR to GTCE https://github.com/GregTechCE/GregTech/pull/1519, I updated our code to allow for fluid tooltips for Simple Fluids as well.

There are 2 parts to this PR:
- Fluid tooltips on Minecraft Buckets
These had to be handled separately, so I handled them in our `ClientProxy` class.

- Fluid tooltips in JEI and in machines
These will not be implemented with this PR. I know, weird right? Well let me explain. This PR includes a coremod for a method in GTCE, `formulaHook`, which I added in my GTCE PR for their fluid tooltips. Now, since this PR is not yet released, our tooltips will similarly not be there in these cases either. However, as soon as that feature is included in GTCE, it will be included for us.

This coremod does **NOT** depend on the feature being added to GTCE, or on having the proper version. If that method does not exist to inject code into, it will simply not happen and no issues will arise. In this case, tooltips will only occur for buckets, as is the behavior if you were to test this feature with the latest GTCE release.

Some images of a fluid I added a temporary chemical formula to:
![image](https://user-images.githubusercontent.com/10861407/110405222-df286f80-8045-11eb-9df8-5732a879c339.png)
![image](https://user-images.githubusercontent.com/10861407/110405244-e6e81400-8045-11eb-9956-2ada57c93abe.png)
![image](https://user-images.githubusercontent.com/10861407/110405263-ee0f2200-8045-11eb-967f-6143c1d0b5b4.png)

The only reason I am able to get these images is by building a jar of Gregicality with this change, and of GTCE with the PR included.


Included in this PR is the addition of two things to `SimpleFluidMaterial`:
- We are now storing the fluids as a Map of <String, SimpleFluidMaterial> so they are easily and efficiently indexable.
- I added constructors and logic for generating the chemical formula of tooltips, in a way that all of our old constructors will work without issue.