### PR TITLE
Fix Cluster Mill Localization

### DIFF
--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -1214,11 +1214,11 @@ gtadditions.machine.wiremill.luv.name=Elite Wiremill II
 gtadditions.machine.wiremill.zpm.name=Elite Wiremill III
 gtadditions.machine.wiremill.uv.name=Elite Wiremill IV
 
-gtadditions.machine.clustermill.uhv.name=High-Tech Cluster Mill
-gtadditions.machine.clustermill.uev.name=High-Tech Cluster Mill II
-gtadditions.machine.clustermill.uiv.name=High-Tech Cluster Mill III
-gtadditions.machine.clustermill.umv.name=High-Tech Cluster Mill IV
-gtadditions.machine.clustermill.uxv.name=Ultimate Cluster Mill
+gtadditions.machine.cluster_mill.uhv.name=High-Tech Cluster Mill
+gtadditions.machine.cluster_mill.uev.name=High-Tech Cluster Mill II
+gtadditions.machine.cluster_mill.uiv.name=High-Tech Cluster Mill III
+gtadditions.machine.cluster_mill.umv.name=High-Tech Cluster Mill IV
+gtadditions.machine.cluster_mill.uxv.name=Ultimate Cluster Mill
 gtadditions.machine.electric_furnace.uhv.name=High-Tech Electric Furnace
 gtadditions.machine.electric_furnace.uev.name=High-Tech Electric Furnace II
 gtadditions.machine.electric_furnace.uiv.name=High-Tech Electric Furnace III

--- a/src/main/resources/assets/gtadditions/lang/ru_ru.lang
+++ b/src/main/resources/assets/gtadditions/lang/ru_ru.lang
@@ -425,7 +425,7 @@ gtadditions.machine.mixer.zpm.name=Элитный смеситель III
 gtadditions.machine.mixer.uv.name=Элитный смеситель IV
 
 gtadditions.machine.ore_washer.iv.name=Элитный рудопромывочный агрегат
-gtadditions.machine.ore_washer.luv.nameЭлитный рудопромывочный агрегат II
+gtadditions.machine.ore_washer.luv.name=Элитный рудопромывочный агрегат II
 gtadditions.machine.ore_washer.zpm.name=Элитный рудопромывочный агрегат III
 gtadditions.machine.ore_washer.uv.name=Элитный рудопромывочный агрегат IV
 
@@ -1004,7 +1004,7 @@ tile.ga_multiblock_casing.tiered_hull_zpm.name=Интегральный фрей
 tile.ga_multiblock_casing.tiered_hull_zpm.tooltip=§eМаксимальное напряжение - ZPM
 tile.ga_multiblock_casing.tiered_hull_uv.name=Интегральный фреймворк IX
 tile.ga_multiblock_casing.tiered_hull_uv.tooltip=§eМаксимальное напряжение - UV
-tile.ga_multiblock_casing.tiered_hull_max.nameИнтегральный фреймворкk X
+tile.ga_multiblock_casing.tiered_hull_max.name=Интегральный фреймворкk X
 tile.ga_multiblock_casing.tiered_hull_max.tooltip=§eМаксимальное напряжение - MAX
 tile.ga_transparent_casing.borosilicate_reinforced_glass.name=Боросиликатное армированное стекло
 tile.ga_transparent_casing.nickel_reinforced_glass.name=Никелевое армированное стекло
@@ -2274,7 +2274,7 @@ metaitem.electric.motor.uiv.name=Электрический мотор (UIV)
 metaitem.electric.motor.umv.name=Электрический мотор (UMV)
 metaitem.electric.motor.uxv.name=Электрический мотор (UXV)
 metaitem.electric.motor.max.name=Электрический мотор (MAX)
-	
+
 metaitem.field.generator.uhv.name=Генератор поля (UHV)
 metaitem.field.generator.uev.name=Генератор поля (UEV)
 metaitem.field.generator.uiv.name=Генератор поля (UIV)
@@ -2342,11 +2342,11 @@ metaitem.electric.piston.umv.name=Электрический поршень (UMV
 metaitem.electric.piston.uxv.name=Электрический поршень (UXV)
 metaitem.electric.piston.max.name=Электрический поршень (MAX)
 
-gtadditions.machine.clustermill.uhv.name=Высокотехнологичный прокатный станок
-gtadditions.machine.clustermill.uev.name=Высокотехнологичный прокатный станок II
-gtadditions.machine.clustermill.uiv.name=Высокотехнологичный прокатный станок III
-gtadditions.machine.clustermill.umv.name=Высокотехнологичный прокатный станок IV
-gtadditions.machine.clustermill.uxv.name=Совершенный прокатный станок
+gtadditions.machine.cluster_mill.uhv.name=Высокотехнологичный прокатный станок
+gtadditions.machine.cluster_mill.uev.name=Высокотехнологичный прокатный станок II
+gtadditions.machine.cluster_mill.uiv.name=Высокотехнологичный прокатный станок III
+gtadditions.machine.cluster_mill.umv.name=Высокотехнологичный прокатный станок IV
+gtadditions.machine.cluster_mill.uxv.name=Совершенный прокатный станок
 gtadditions.machine.electric_furnace.uhv.name=Высокотехнологичная электрическая печь
 gtadditions.machine.electric_furnace.uev.name=Высокотехнологичная электрическая печь II
 gtadditions.machine.electric_furnace.uiv.name=Высокотехнологичная электрическая печь III

--- a/src/main/resources/assets/gtadditions/lang/zh_cn.lang
+++ b/src/main/resources/assets/gtadditions/lang/zh_cn.lang
@@ -1191,11 +1191,11 @@ gtadditions.machine.wiremill.luv.name=精英线材轧机 II
 gtadditions.machine.wiremill.zpm.name=精英线材轧机 III
 gtadditions.machine.wiremill.uv.name=精英线材轧机 IV
 
-gtadditions.machine.clustermill.uhv.name=次世代多辊式轧机
-gtadditions.machine.clustermill.uev.name=次世代多辊式轧机 II
-gtadditions.machine.clustermill.uiv.name=次世代多辊式轧机 III
-gtadditions.machine.clustermill.umv.name=次世代多辊式轧机 IV
-gtadditions.machine.clustermill.uxv.name=终焉多辊式轧机
+gtadditions.machine.cluster_mill.uhv.name=次世代多辊式轧机
+gtadditions.machine.cluster_mill.uev.name=次世代多辊式轧机 II
+gtadditions.machine.cluster_mill.uiv.name=次世代多辊式轧机 III
+gtadditions.machine.cluster_mill.umv.name=次世代多辊式轧机 IV
+gtadditions.machine.cluster_mill.uxv.name=终焉多辊式轧机
 gtadditions.machine.electric_furnace.uhv.name=次世代热应激发生器
 gtadditions.machine.electric_furnace.uev.name=次世代热应激发生器 II
 gtadditions.machine.electric_furnace.uiv.name=次世代热应激发生器 III


### PR DESCRIPTION
This PR simply fixes the issue where UHV+ Cluster Mills had a bad translation key being used in the lang.

While fixing this for the `ru_ru` localization, I noticed there were a few issues with the lang file, thanks to an Intellij plugin I'm using that provides syntax highlighting. I fixed these issues as well.

Closes #402 