### PR TITLE
Fix Missing JSON for Uranium Saturated Yarn

### DIFF
--- a/src/main/resources/assets/gregtech/models/item/metaitems/uranium_saturated_yarn.json
+++ b/src/main/resources/assets/gregtech/models/item/metaitems/uranium_saturated_yarn.json
@@ -1,0 +1,7 @@
+
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "gregtech:items/metaitems/uranium_saturated_yarn"
+  }
+}


### PR DESCRIPTION
This is a simple PR that adds the missing JSON model for Uranium Saturated Yarn, which previously caused it to show up as a missing texture in-game.