### PR TITLE
Fix GTCE Polarizer recipes not getting removed

### DIFF
--- a/src/main/java/gregicadditions/recipes/MachineCraftingRecipes.java
+++ b/src/main/java/gregicadditions/recipes/MachineCraftingRecipes.java
@@ -83,7 +83,7 @@ public class MachineCraftingRecipes {
             ModHandler.removeRecipeByName(new ResourceLocation("gregtech:gregtech.machine.fluid_solidifier." + tier));
             ModHandler.removeRecipeByName(new ResourceLocation("gregtech:gregtech.machine.distillery." + tier));
             ModHandler.removeRecipeByName(new ResourceLocation("gregtech:gregtech.machine.chemical_bath." + tier));
-            ModHandler.removeRecipeByName(new ResourceLocation("gregtech:gregtech.machine.polarizor." + tier));
+            ModHandler.removeRecipeByName(new ResourceLocation("gregtech:gregtech.machine.polarizer." + tier));
             ModHandler.removeRecipeByName(new ResourceLocation("gregtech:gregtech.machine.electromagnetic_separator." + tier));
             ModHandler.removeRecipeByName(new ResourceLocation("gregtech:gregtech.machine.autoclave." + tier));
             ModHandler.removeRecipeByName(new ResourceLocation("gregtech:gregtech.machine.mixer." + tier));


### PR DESCRIPTION
Fixes a Typo that prevents LV-EV GTCE Polarizers not having their recipes removed, causing duplicate recipes with the Gregicality recipes.