### PR TITLE
Fix Insulation Wire Assembly Recipes

### DIFF
--- a/src/main/java/gregicadditions/recipes/RecipeHandler.java
+++ b/src/main/java/gregicadditions/recipes/RecipeHandler.java
@@ -224,6 +224,8 @@ public class RecipeHandler {
 
         int tier = GAUtility.getTierByVoltage(material.cableProperties.voltage);
         int cableSize = ArrayUtils.indexOf(WIRE_DOUBLING_ORDER, wireGt);
+        int expensiveAmount = (cableAmount == 1) ? 1 : cableAmount / 2;
+
         if (wireGt != wireGtSingle) {
             switch (tier) {
                 case 0:
@@ -246,13 +248,9 @@ public class RecipeHandler {
                     RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().circuitMeta(24 + cableSize).input(wireGtSingle, material, cableAmount).input(foil, Polyetheretherketone, cableAmount).outputs(cableStack).duration(150).EUt(8).buildAndRegister();
                 case 12:
                 case 13:
-                    cableStack = OreDictUnifier.get(cablePrefix, material,4);
-                    RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().circuitMeta(24 + cableSize).input(wireGtSingle, material, 4*cableAmount).inputs(INSULATION_WIRE_ASSEMBLY.getStackForm(2*cableAmount)).input(foil, Zylon, (cableAmount == 1) ? 1 : cableAmount/2).outputs(cableStack).duration(150).EUt(8).buildAndRegister();
+                    RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().circuitMeta(24 + cableSize).input(wireGtSingle, material, cableAmount).inputs(INSULATION_WIRE_ASSEMBLY.getStackForm(expensiveAmount)).input(foil, Zylon, expensiveAmount).outputs(cableStack).duration(150).EUt(8).buildAndRegister();
                 default:
-                    cableStack = OreDictUnifier.get(cablePrefix, material,4);
-                    RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().circuitMeta(24 + cableSize).input(wireGtSingle, material, 4*cableAmount).inputs(INSULATION_WIRE_ASSEMBLY.getStackForm(2*cableAmount)).input(foil, FullerenePolymerMatrix, (cableAmount == 1) ? 1 : cableAmount/2).outputs(cableStack).duration(150).EUt(8).buildAndRegister();
-
-
+                    RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().circuitMeta(24 + cableSize).input(wireGtSingle, material, cableAmount).inputs(INSULATION_WIRE_ASSEMBLY.getStackForm(expensiveAmount)).input(foil, FullerenePolymerMatrix, expensiveAmount).outputs(cableStack).duration(150).EUt(8).buildAndRegister();
             }
         }
         switch (tier) {
@@ -276,14 +274,10 @@ public class RecipeHandler {
                 RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().circuitMeta(24).input(wireGt, material).input(foil, Polyetheretherketone, cableAmount).outputs(cableStack).duration(150).EUt(8).buildAndRegister();
             case 12:
             case 13:
-                RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().circuitMeta(24).input(wireGt, material, 4).input(foil, Zylon, (cableAmount == 1) ? 1 : cableAmount/2).inputs(INSULATION_WIRE_ASSEMBLY.getStackForm(2*cableAmount)).outputs(cableStack).duration(150).EUt(8).buildAndRegister();
+                RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().circuitMeta(24).input(wireGt, material).input(foil, Zylon, expensiveAmount).inputs(INSULATION_WIRE_ASSEMBLY.getStackForm(expensiveAmount)).outputs(cableStack).duration(150).EUt(8).buildAndRegister();
             default:
-                RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().circuitMeta(24).input(wireGt, material, 4).input(foil, FullerenePolymerMatrix, (cableAmount == 1) ? 1 : cableAmount/2).inputs(INSULATION_WIRE_ASSEMBLY.getStackForm(2*cableAmount)).outputs(cableStack).duration(150).EUt(8).buildAndRegister();
-
-
+                RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().circuitMeta(24).input(wireGt, material).input(foil, FullerenePolymerMatrix, expensiveAmount).inputs(INSULATION_WIRE_ASSEMBLY.getStackForm(expensiveAmount)).outputs(cableStack).duration(150).EUt(8).buildAndRegister();
         }
-
-
     }
 
     private static void processRing(OrePrefix ring, IngotMaterial material) {


### PR DESCRIPTION
Fixes an issue where wire recipes using Insulation Wire Assembly had bad recipe amounts.

Since Insulation Wire Assembly is expensive, the recipes were trying to follow the pattern:
`wireInsulationAmount = (cableAmount == 1) ? 1 : cableAmount / 2`
to save on resources, but was accidentally not doing this, and changing the cable amount too. It now follows this ternary pattern.

Old:
![old](https://user-images.githubusercontent.com/10861407/111569585-f1568c00-8770-11eb-9dce-cb2d162a3495.png)

New (1x):
![1x](https://user-images.githubusercontent.com/10861407/111569592-f74c6d00-8770-11eb-95cb-0e4193a607c2.png)

New (2x):
![2xpt1](https://user-images.githubusercontent.com/10861407/111569603-fb788a80-8770-11eb-895b-954230572492.png)

New (4x):
![4x](https://user-images.githubusercontent.com/10861407/111569619-00d5d500-8771-11eb-99f3-1b1fcae0e713.png)

This is not an inclusive list of the recipes, but they are all fine now, and these screenshots show the pattern.