### PR TITLE
Fix NotConsumed Fluids in Large Multis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     deobfCompile "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.20.554"
     deobfCompile "mezz.jei:jei_1.12.2:+"
     deobfCompile "net.sengir.forestry:forestry_1.12.2:5.8.2.387"
-    deobfCompile "gregtechce:gregtech:1.12.2:1.12.1.669"
+    deobfCompile "gregtechce:gregtech:1.12.2:1.13.0.681"
     deobfCompile "codechicken:ChickenASM:1.12-1.0.2.9"
     deobfCompile "codechicken-lib-1-8:CodeChickenLib-1.12.2:3.2.3.358:universal"
     deobfCompile "forge-multipart-cbe:ForgeMultipart-1.12.2:2.6.2.83:universal"

--- a/src/main/java/gregicadditions/Gregicality.java
+++ b/src/main/java/gregicadditions/Gregicality.java
@@ -35,7 +35,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import java.io.IOException;
 
 @Mod(modid = Gregicality.MODID, name = Gregicality.NAME, version = Gregicality.VERSION,
-        dependencies = "required-after:gregtech;" +
+        dependencies = "required-after:gregtech@[1.13.0.681,);" +
                 "after:forestry;" +
                 "after:tconstruct;" +
                 "after:exnihilocreatio;" +

--- a/src/main/java/gregicadditions/machines/multi/simple/LargeSimpleRecipeMapMultiblockController.java
+++ b/src/main/java/gregicadditions/machines/multi/simple/LargeSimpleRecipeMapMultiblockController.java
@@ -420,10 +420,12 @@ abstract public class LargeSimpleRecipeMapMultiblockController extends GARecipeM
         protected int getMinRatioFluid(Map<String, Integer> countFluid, Recipe r, int maxItemsLimit) {
             int minMultiplier = Integer.MAX_VALUE;
             for (FluidStack fs : r.getFluidInputs()) {
-                String name = fs.getFluid().getUnlocalizedName();
-                int ratio = Math.min(maxItemsLimit, countFluid.get(name) / fs.amount);
-                if (ratio < minMultiplier) {
-                    minMultiplier = ratio;
+                if (fs.amount != 0) { // skip notConsumable fluids
+                    String name = fs.getFluid().getUnlocalizedName();
+                    int ratio = Math.min(maxItemsLimit, countFluid.get(name) / fs.amount);
+                    if (ratio < minMultiplier) {
+                        minMultiplier = ratio;
+                    }
                 }
             }
             return minMultiplier;


### PR DESCRIPTION
This PR does two things:
- Updates our GTCE dependency to 1.13.0, and sets a `required-after:gregtech[1.13.0,)` since many of our chemical chains are going to depend on a new GTCE feature introduced in 1.13.0, https://github.com/GregTechCE/GregTech/pull/1514
- Fixes Large Multis not being able to handle notConsumed fluids due to a divide by 0 exception