### PR TITLE
fix PA not running due to add the machinestack as recipe input

### DIFF
--- a/src/main/java/gregicadditions/machines/multi/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/multi/TileEntityProcessingArray.java
@@ -12,7 +12,6 @@ import gregicadditions.utils.GALog;
 import gregtech.api.GregTechAPI;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.capability.IMultipleTankHandler;
-import gregtech.api.capability.impl.AbstractRecipeLogic;
 import gregtech.api.metatileentity.ITieredMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
@@ -34,12 +33,11 @@ import net.minecraft.util.text.Style;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.event.HoverEvent;
+import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidTank;
-import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
-import java.lang.reflect.Field;
 import java.util.*;
 
 import static gregtech.api.unification.material.Materials.TungstenSteel;
@@ -51,7 +49,6 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockWithSlotContro
     public TileEntityProcessingArray(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId, GARecipeMaps.PROCESSING_ARRAY_RECIPES, ITieredMetaTileEntity.class);
         ProcessingArrayWorkable recipeLogic = new ProcessingArrayWorkable(this);
-        recipeLogic.initReflection();
         this.recipeMapWorkable = recipeLogic;
     }
 
@@ -128,14 +125,9 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockWithSlotContro
         int numberOfMachines = 0;
         int numberOfOperations = 0;
         ItemStack machineItemStack = null;
-        Field wasActiveAndNeedsUpdateField = null;
-        Field hasNotEnoughEnergyField = null;
+        private ItemStack lastMachine;
+        private RecipeMap<?> lastRecipeMap;
         String recipeMapName = null;
-
-        public void initReflection() {
-            wasActiveAndNeedsUpdateField = ObfuscationReflectionHelper.findField(AbstractRecipeLogic.class, "wasActiveAndNeedsUpdate");
-            hasNotEnoughEnergyField = ObfuscationReflectionHelper.findField(AbstractRecipeLogic.class, "hasNotEnoughEnergy");
-        }
 
         public ProcessingArrayWorkable(RecipeMapMultiblockController tileEntity) {
             super(tileEntity);
@@ -173,7 +165,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockWithSlotContro
 
             }
 
-            Map<String, Integer> countFluid = new HashMap<>();
+            Map<Fluid, Integer> countFluid = new HashMap<>();
             if (recipePerInput.getKey().getFluidInputs().size() != 0) {
 
                 this.findFluid(countFluid, fluidInputs);
@@ -202,7 +194,6 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockWithSlotContro
                     .duration(recipePerInput.getKey().getDuration());
 
             copyChancedItemOutputs(newRecipe, recipePerInput.getKey(), numberOfOperations);
-            newRecipe.notConsumable(machineItemStack);
 
             return newRecipe.build().getResult();
         }
@@ -225,7 +216,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockWithSlotContro
                 String name = wholeItemStack.getItem().getUnlocalizedNameInefficiently(wholeItemStack);
 
                 // skip empty slots
-                if (name.equals("tile.air")) {
+                if (wholeItemStack.isEmpty()) {
                     continue;
                 }
 
@@ -265,30 +256,30 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockWithSlotContro
             return minMultiplier;
         }
 
-        protected void findFluid(Map<String, Integer> countFluid, IMultipleTankHandler fluidInputs) {
+        protected void findFluid(Map<Fluid, Integer> countFluid, IMultipleTankHandler fluidInputs) {
 
             for (IFluidTank tank : fluidInputs) {
 
                 if (tank.getFluid() != null) {
 
-                    String name = tank.getFluid().getUnlocalizedName();
+                    Fluid fluid = tank.getFluid().getFluid();
 
-                    if (countFluid.containsKey(name)) {
-                        int existingValue = countFluid.get(name);
-                        countFluid.put(name, existingValue + tank.getFluidAmount());
+                    if (countFluid.containsKey(fluid)) {
+                        int existingValue = countFluid.get(fluid);
+                        countFluid.put(fluid, existingValue + tank.getFluidAmount());
 
                     } else {
-                        countFluid.put(name, tank.getFluidAmount());
+                        countFluid.put(fluid, tank.getFluidAmount());
                     }
                 }
             }
         }
 
-        protected int getMinRatioFluid(Map<String, Integer> countFluid, Recipe r, int numberOfMachines) {
+        protected int getMinRatioFluid(Map<Fluid, Integer> countFluid, Recipe r, int numberOfMachines) {
             int minMultiplier = Integer.MAX_VALUE;
             for (FluidStack fs : r.getFluidInputs()) {
-                String name = fs.getFluid().getUnlocalizedName();
-                int ratio = Math.min(numberOfMachines, countFluid.get(name) / fs.amount);
+                Fluid fluid = fs.getFluid();
+                int ratio = Math.min(numberOfMachines, countFluid.get(fluid) / fs.amount);
 
                 if (ratio < minMultiplier) {
                     minMultiplier = ratio;
@@ -321,8 +312,12 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockWithSlotContro
         }
 
         protected RecipeMap<?> findRecipeMap(ItemStack machine) {
-            if (machine == null)
+            if (machine.isEmpty())
                 return null;
+
+            if (lastMachine != null && machine.isItemEqual(lastMachine) && machine.getCount() == lastMachine.getCount())
+                return this.lastRecipeMap;
+            else this.lastMachine = machine.copy();
 
             ITieredMetaTileEntity mte = (ITieredMetaTileEntity) GregTechAPI.META_TILE_ENTITY_REGISTRY.getObjectById(machine.getItemDamage());
             String unlocalizedName = machine.getItem().getUnlocalizedNameInefficiently(machine); // can do this differently
@@ -341,6 +336,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockWithSlotContro
                     // The machine Item Stack. Is this needed if we remove the machine from being found in the ingredients?
                     this.machineItemStack = machine;
 
+                    this.lastRecipeMap = rmap;
                     return rmap;
                 }
             }
@@ -426,14 +422,10 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockWithSlotContro
             this.fluidOutputs = GTUtility.copyFluidList(recipe.getFluidOutputs());
             int tier = getMachineTierForRecipe(recipe);
             this.itemOutputs = GTUtility.copyStackList(recipe.getResultItemOutputs(getOutputInventory().getSlots(), random, tier));
-            try {
-                if (this.wasActiveAndNeedsUpdateField.getBoolean(this)) {
-                    this.wasActiveAndNeedsUpdateField.set(this, false);
-                } else {
-                    setActive(true);
-                }
-            } catch (IllegalAccessException e) {
-                e.printStackTrace();
+            if (this.wasActiveAndNeedsUpdate) {
+                this.wasActiveAndNeedsUpdate = false;
+            } else {
+                setActive(true);
             }
         }
     }


### PR DESCRIPTION
supersedes #426

After the recipe was built it the PA adds the machine in the dedicate slot as an input of the recipe, due to leftover of the old logic when the machine stack worked from inside the bus.

removed adding machine stack to the recipe when setting the machine stack to not consumable.
removed reflection.
removed comparison by string references