### PR TITLE
Move Recipe Reversal Recipes to After CT

### DIFF
--- a/src/main/java/gregicadditions/CommonProxy.java
+++ b/src/main/java/gregicadditions/CommonProxy.java
@@ -58,6 +58,7 @@ public class CommonProxy {
     }
 
     public void onLoad() throws IOException {
+        registerRecipesAfterCT();
         WorldGenRegister.init();
         if (GAConfig.Misc.multiStoneGen) {
             MinecraftForge.EVENT_BUS.register(new StoneGenEvents());
@@ -196,9 +197,15 @@ public class CommonProxy {
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public static void registerRecipesLowest(RegistryEvent.Register<IRecipe> event) {
         RecipeHandler.runRecipeGeneration();
+    }
+
+    // These recipes are generated at the beginning of the init() phase
+    // This is not great practice, but ensures that they are run
+    // AFTER CraftTweaker, meaning they will follow the recipes in the map
+    // with CraftTweaker changes, being significantly easier for modpack authors.
+    private static void registerRecipesAfterCT() {
         ElectricImplosionHandler.buildElectricImplosionRecipes();
-        if (GAConfig.Misc.enableDisassembly)
-            DisassemblyHandler.buildDisassemblerRecipes();
+        DisassemblyHandler.buildDisassemblerRecipes();
     }
 
 

--- a/src/main/java/gregicadditions/recipes/ElectricImplosionHandler.java
+++ b/src/main/java/gregicadditions/recipes/ElectricImplosionHandler.java
@@ -13,6 +13,7 @@ import net.minecraft.item.crafting.Ingredient;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 public class ElectricImplosionHandler {
@@ -46,8 +47,6 @@ public class ElectricImplosionHandler {
      * NOTE that this does NOT have any checking for integrated circuits
      * or other not-consumed items. If we add these to the default
      * Implosion Compressor, this code will have to be adjusted.
-     * CraftTweaker recipes do not matter for this issue, as their
-     * recipe registration is after this is run.
      */
     public static void buildElectricImplosionRecipes() {
 
@@ -62,12 +61,15 @@ public class ElectricImplosionHandler {
             }
 
             // Get the input list, converting from CountableIngredient to ItemStack
+            AtomicInteger stackCount = new AtomicInteger();
             Set<ItemStack> inputs = new ObjectOpenCustomHashSet<>(strategy);
             inputs.addAll(recipe.getInputs().stream()
+                                            .peek(ing -> stackCount.set(ing.getCount()))
                                             .map(CountableIngredient::getIngredient)
                                             .map(Ingredient::getMatchingStacks)
                                             .filter(stack -> stack.length != 0)
                                             .map(array -> array[0])
+                                            .peek(is -> is.setCount(stackCount.get()))
                                             .collect(Collectors.toSet()));
 
             // Make sure inputs were properly acquired, and remove explosive


### PR DESCRIPTION
This PR is simple, and moves both the Electric Implosion Compressor and Disassembler recipe generation calls to be after CraftTweaker recipes have been generated. This way, these two machines will properly respect the updated recipes instead of needing to be manually changed for all CraftTweaker changes implemented.

This is extremely straightforward for the Electric Implosion Compressor, but for the Disassembler, it may be unwanted, so there is still always the config option for it.

Secondly, I fixed an issue with the Electric Implosion recipe generator where it did not respect the stack size of the input ingredient.