### PR TITLE
Remove scheduleRenderUpdate() method calls

### DIFF
--- a/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargeBenderAndForming.java
+++ b/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargeBenderAndForming.java
@@ -4,6 +4,7 @@ import codechicken.lib.raytracer.CuboidRayTraceResult;
 import gregicadditions.GAConfig;
 import gregicadditions.capabilities.GregicAdditionsCapabilities;
 import gregicadditions.capabilities.IMultiRecipe;
+import gregicadditions.client.ClientHandler;
 import gregicadditions.item.GAMetaBlocks;
 import gregicadditions.item.components.MotorCasing;
 import gregicadditions.item.components.PistonCasing;
@@ -150,6 +151,7 @@ public class TileEntityLargeBenderAndForming extends LargeSimpleRecipeMapMultibl
         this.pos = data.getInteger("Recipe");
         ((LargeSimpleMultiblockRecipeLogic) (this.recipeMapWorkable)).recipeMap = possibleRecipe[pos];
         this.recipeMap = possibleRecipe[pos];
+        this.scheduleRenderUpdate();
     }
 
     @Override

--- a/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargeBenderAndForming.java
+++ b/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargeBenderAndForming.java
@@ -134,7 +134,6 @@ public class TileEntityLargeBenderAndForming extends LargeSimpleRecipeMapMultibl
             this.recipeMap = possibleRecipe[pos];
         }
 
-        this.scheduleRenderUpdate();
         return true; // return true here on the server to keep the GUI closed
     }
 
@@ -151,7 +150,6 @@ public class TileEntityLargeBenderAndForming extends LargeSimpleRecipeMapMultibl
         this.pos = data.getInteger("Recipe");
         ((LargeSimpleMultiblockRecipeLogic) (this.recipeMapWorkable)).recipeMap = possibleRecipe[pos];
         this.recipeMap = possibleRecipe[pos];
-        this.scheduleRenderUpdate();
     }
 
     @Override

--- a/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargeBenderAndForming.java
+++ b/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargeBenderAndForming.java
@@ -4,7 +4,6 @@ import codechicken.lib.raytracer.CuboidRayTraceResult;
 import gregicadditions.GAConfig;
 import gregicadditions.capabilities.GregicAdditionsCapabilities;
 import gregicadditions.capabilities.IMultiRecipe;
-import gregicadditions.client.ClientHandler;
 import gregicadditions.item.GAMetaBlocks;
 import gregicadditions.item.components.MotorCasing;
 import gregicadditions.item.components.PistonCasing;

--- a/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargeMultiUse.java
+++ b/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargeMultiUse.java
@@ -142,7 +142,6 @@ public class TileEntityLargeMultiUse extends LargeSimpleRecipeMapMultiblockContr
             this.recipeMap = possibleRecipe[pos];
         }
 
-        this.scheduleRenderUpdate();
         return true; // return true here on the server to keep the GUI closed
     }
 
@@ -159,7 +158,6 @@ public class TileEntityLargeMultiUse extends LargeSimpleRecipeMapMultiblockContr
         this.pos = data.getInteger("Recipe");
         ((LargeSimpleMultiblockRecipeLogic) (this.recipeMapWorkable)).recipeMap = possibleRecipe[pos];
         this.recipeMap = possibleRecipe[pos];
-        this.scheduleRenderUpdate();
     }
 
     @Override

--- a/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargeMultiUse.java
+++ b/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargeMultiUse.java
@@ -159,6 +159,7 @@ public class TileEntityLargeMultiUse extends LargeSimpleRecipeMapMultiblockContr
         this.pos = data.getInteger("Recipe");
         ((LargeSimpleMultiblockRecipeLogic) (this.recipeMapWorkable)).recipeMap = possibleRecipe[pos];
         this.recipeMap = possibleRecipe[pos];
+        this.scheduleRenderUpdate();
     }
 
     @Override

--- a/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargePackager.java
+++ b/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargePackager.java
@@ -147,6 +147,7 @@ public class TileEntityLargePackager extends LargeSimpleRecipeMapMultiblockContr
         this.pos = data.getInteger("Recipe");
         ((LargeSimpleMultiblockRecipeLogic) (this.recipeMapWorkable)).recipeMap = possibleRecipe[pos];
         this.recipeMap = possibleRecipe[pos];
+        this.scheduleRenderUpdate();
     }
 
     @Override

--- a/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargePackager.java
+++ b/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargePackager.java
@@ -130,7 +130,6 @@ public class TileEntityLargePackager extends LargeSimpleRecipeMapMultiblockContr
             this.recipeMap = possibleRecipe[pos];
         }
 
-        this.scheduleRenderUpdate();
         return true; // return true here on the server to keep the GUI closed
     }
 
@@ -147,7 +146,6 @@ public class TileEntityLargePackager extends LargeSimpleRecipeMapMultiblockContr
         this.pos = data.getInteger("Recipe");
         ((LargeSimpleMultiblockRecipeLogic) (this.recipeMapWorkable)).recipeMap = possibleRecipe[pos];
         this.recipeMap = possibleRecipe[pos];
-        this.scheduleRenderUpdate();
     }
 
     @Override

--- a/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargeWashingPlant.java
+++ b/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargeWashingPlant.java
@@ -147,6 +147,7 @@ public class TileEntityLargeWashingPlant extends LargeSimpleRecipeMapMultiblockC
         this.pos = data.getInteger("Recipe");
         ((LargeSimpleMultiblockRecipeLogic) (this.recipeMapWorkable)).recipeMap = possibleRecipe[pos];
         this.recipeMap = possibleRecipe[pos];
+        this.scheduleRenderUpdate();
     }
 
     @Override

--- a/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargeWashingPlant.java
+++ b/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargeWashingPlant.java
@@ -130,7 +130,6 @@ public class TileEntityLargeWashingPlant extends LargeSimpleRecipeMapMultiblockC
             this.recipeMap = possibleRecipe[pos];
         }
 
-        this.scheduleRenderUpdate();
         return true; // return true here on the server to keep the GUI closed
     }
 
@@ -147,7 +146,6 @@ public class TileEntityLargeWashingPlant extends LargeSimpleRecipeMapMultiblockC
         this.pos = data.getInteger("Recipe");
         ((LargeSimpleMultiblockRecipeLogic) (this.recipeMapWorkable)).recipeMap = possibleRecipe[pos];
         this.recipeMap = possibleRecipe[pos];
-        this.scheduleRenderUpdate();
     }
 
     @Override


### PR DESCRIPTION
Potentially prevents a race condition on world load causing an NPE. This should fix it.