### PR TITLE
Drop NBT From JEI Recipes

### DIFF
--- a/src/main/java/gregicadditions/recipes/wrapper/GARecipeWrapper.java
+++ b/src/main/java/gregicadditions/recipes/wrapper/GARecipeWrapper.java
@@ -1,25 +1,24 @@
 package gregicadditions.recipes.wrapper;
 
-import codechicken.lib.util.ItemNBTUtils;
 import gregicadditions.GAValues;
 import gregtech.api.recipes.CountableIngredient;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.Recipe.ChanceEntry;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.unification.OreDictUnifier;
+import gregtech.api.util.ItemStackHashStrategy;
+import it.unimi.dsi.fastutil.Hash;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenCustomHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectOpenCustomHashSet;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fluids.FluidStack;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class GARecipeWrapper implements IRecipeWrapper {
@@ -27,6 +26,12 @@ public class GARecipeWrapper implements IRecipeWrapper {
     private static final int lineHeight = 10;
     private final RecipeMap<?> recipeMap;
     private final Recipe recipe;
+
+    private final Hash.Strategy<ItemStack> strategy = ItemStackHashStrategy.comparingAllButCount();
+
+    private final Set<ItemStack> notConsumedInput = new ObjectOpenCustomHashSet<>(strategy);
+    private final Map<ItemStack, ChanceEntry> chanceOutput = new Object2ObjectOpenCustomHashMap<>(strategy);
+    private final List<FluidStack> notConsumedFluidInput = new ArrayList<>();
 
     public GARecipeWrapper(RecipeMap<?> recipeMap, Recipe recipe) {
         this.recipeMap = recipeMap;
@@ -45,7 +50,7 @@ public class GARecipeWrapper implements IRecipeWrapper {
                         .collect(Collectors.toList());
                 ingredientValues.forEach(stack -> {
                     if (ingredient.getCount() == 0) {
-                        ItemNBTUtils.setBoolean(stack, "not_consumed", true);
+                        notConsumedInput.add(stack);
                         stack.setCount(1);
                     } else stack.setCount(ingredient.getCount());
                 });
@@ -60,9 +65,7 @@ public class GARecipeWrapper implements IRecipeWrapper {
                     .collect(Collectors.toList());
             recipeInputs.forEach(stack -> {
                 if (stack.amount == 0) {
-                    if (stack.tag == null)
-                        stack.tag = new NBTTagCompound();
-                    stack.tag.setBoolean("not_consumed", true);
+                    notConsumedFluidInput.add(stack);
                     stack.amount = 1;
                 }
             });
@@ -75,11 +78,16 @@ public class GARecipeWrapper implements IRecipeWrapper {
             List<ChanceEntry> chancedOutputs = recipe.getChancedOutputs();
             for (ChanceEntry chancedEntry : chancedOutputs) {
                 ItemStack chancedStack = chancedEntry.getItemStack();
-                ItemNBTUtils.setInteger(chancedStack, "chance", chancedEntry.getChance());
-                ItemNBTUtils.setInteger(chancedStack, "boost_per_tier", chancedEntry.getBoostPerTier());
+                chanceOutput.put(chancedStack, chancedEntry);
                 recipeOutputs.add(chancedStack);
             }
-            recipeOutputs.sort(Comparator.comparing(stack -> ItemNBTUtils.getInteger(stack, "chance")));
+
+            recipeOutputs.sort(Comparator.comparingInt(stack -> {
+                ChanceEntry chanceEntry = chanceOutput.get(stack);
+                if (chanceEntry == null)
+                    return 0;
+                return chanceEntry.getChance();
+            }));
             ingredients.setOutputs(VanillaTypes.ITEM, recipeOutputs);
         }
 
@@ -91,20 +99,26 @@ public class GARecipeWrapper implements IRecipeWrapper {
     }
 
     public void addTooltip(int slotIndex, boolean input, Object ingredient, List<String> tooltip) {
-        NBTTagCompound tagCompound;
-        if (ingredient instanceof ItemStack) {
-            tagCompound = ((ItemStack) ingredient).getTagCompound();
-        } else if (ingredient instanceof FluidStack) {
-            tagCompound = ((FluidStack) ingredient).tag;
+        boolean notConsumed = false;
+        ChanceEntry entry = null;
+        if (ingredient instanceof FluidStack) {
+            FluidStack fluidStack = ((FluidStack) ingredient);
+            if (notConsumedFluidInput.contains(fluidStack))
+                notConsumed = true;
+        } else if (ingredient instanceof ItemStack) {
+            ItemStack itemStack = ((ItemStack) ingredient);
+            if (notConsumedInput.contains(itemStack))
+                notConsumed = true;
+            else entry = chanceOutput.get(itemStack);
         } else {
             throw new IllegalArgumentException("Unknown ingredient type: " + ingredient.getClass());
         }
-        if (tagCompound != null && tagCompound.hasKey("chance")) {
-            String chanceString = Recipe.formatChanceValue(tagCompound.getInteger("chance"));
-            String boostString = Recipe.formatChanceValue(tagCompound.getInteger("boost_per_tier"));
-            tooltip.add(I18n.format("gregtech.recipe.chance", chanceString, boostString));
 
-        } else if (tagCompound != null && tagCompound.hasKey("not_consumed")) {
+        if (entry != null) {
+            double chance = entry.getChance() / 100.0;
+            double boost = entry.getBoostPerTier() / 100.0;
+            tooltip.add(I18n.format("gregtech.recipe.chance", chance, boost));
+        } else if (notConsumed) {
             tooltip.add(I18n.format("gregtech.recipe.not_consumed"));
         }
     }


### PR DESCRIPTION
This PR mirrors a change made in GTCE to drop NBT for JEI recipes for things like chanced outputs, not consumed inputs, etc in favor of a cached value. See https://github.com/GregTechCE/GregTech/pull/1516 for information.

The primary reason for this (aside from a cleaner implementation not requiring NBT) is because JEI lacks a subtype handler for fluids in 1.12.2. This means that it is unable to differentiate fluids with NBT data. For example,
- Water would have a JEI uid of:
`fluid:water`
- Water, but set as not consumable, with an NBT tag to mark it would have a JEI uid of:
`fluid:water{not_consumed:1b}`

This results in JEI treating Water and "Not Consumable Water" as two different ingredients, leading to recipe lookup failing for not consumable fluids. By dropping NBT, this is a non-issue.

See https://github.com/GregTechCE/GregTech/pull/1514 for some more explanation and a suggestion from mezz to do it this way.