### PR TITLE
Fix breaking particles for Drum and Crate

### DIFF
--- a/src/main/java/gregicadditions/machines/MetaTileEntityDrum.java
+++ b/src/main/java/gregicadditions/machines/MetaTileEntityDrum.java
@@ -10,6 +10,7 @@ import gregicadditions.client.ClientHandler;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.recipes.ModHandler;
 import gregtech.api.unification.material.type.Material;
 import gregtech.api.unification.material.type.SolidMaterial;
 import gregtech.api.util.GTUtility;
@@ -169,7 +170,16 @@ public class MetaTileEntityDrum extends MetaTileEntity {
 	@Override
 	@SideOnly(Side.CLIENT)
 	public Pair<TextureAtlasSprite, Integer> getParticleTexture() {
-		return Pair.of(material.toString().contains("wood") ? ClientHandler.BARREL.getParticleTexture() : ClientHandler.DRUM.getParticleTexture(), 16777215);
+		if(ModHandler.isMaterialWood(material)) {
+			return Pair.of(ClientHandler.BARREL.getParticleTexture(), getPaintingColor());
+		}
+		else {
+			int color = ColourRGBA.multiply(
+					GTUtility.convertRGBtoOpaqueRGBA_CL(material.materialRGB),
+					GTUtility.convertRGBtoOpaqueRGBA_CL(getPaintingColor()));
+			color = GTUtility.convertOpaqueRGBA_CLtoRGB(color);
+			return Pair.of(ClientHandler.DRUM.getParticleTexture(), color);
+		}
 	}
 
 	@Override

--- a/src/main/java/gregicadditions/machines/TileEntityBuffer.java
+++ b/src/main/java/gregicadditions/machines/TileEntityBuffer.java
@@ -5,8 +5,8 @@ import codechicken.lib.render.pipeline.ColourMultiplier;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
 import codechicken.lib.vec.Vector3;
+import gregicadditions.client.ClientHandler;
 import gregtech.api.capability.impl.FilteredFluidHandler;
-import gregtech.api.capability.impl.FluidHandlerProxy;
 import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
@@ -16,12 +16,14 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.render.Textures;
 import gregtech.api.util.GTUtility;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.items.ItemStackHandler;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.tuple.Pair;
 
 public class TileEntityBuffer extends MetaTileEntity implements ITieredMetaTileEntity {
 
@@ -58,6 +60,10 @@ public class TileEntityBuffer extends MetaTileEntity implements ITieredMetaTileE
         return new TileEntityBuffer(metaTileEntityId, tier);
     }
 
+    @Override
+    public Pair<TextureAtlasSprite, Integer> getParticleTexture() {
+        return Pair.of(ClientHandler.VOLTAGE_CASINGS[this.tier].getParticleSprite(), this.getPaintingColor());
+    }
 
     @Override
     protected ModularUI createUI(EntityPlayer entityPlayer) {

--- a/src/main/java/gregicadditions/machines/TileEntityCrate.java
+++ b/src/main/java/gregicadditions/machines/TileEntityCrate.java
@@ -10,7 +10,7 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.ModularUI.Builder;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
-import gregtech.api.render.Textures;
+import gregtech.api.recipes.ModHandler;
 import gregtech.api.unification.material.type.SolidMaterial;
 import gregtech.api.util.GTUtility;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -88,7 +88,16 @@ public class TileEntityCrate extends MetaTileEntity {
 	@Override
 	@SideOnly(Side.CLIENT)
 	public Pair<TextureAtlasSprite, Integer> getParticleTexture() {
-		return Pair.of(material.toString().contains("wood") ? Textures.WOODEN_CHEST.getParticleTexture() : ClientHandler.METAL_CRATE.getParticleTexture(), 16777215);
+		if(ModHandler.isMaterialWood(material)) {
+			return Pair.of(ClientHandler.WOODEN_CRATE.getParticleTexture(), getPaintingColor());
+		}
+		else {
+			int color = ColourRGBA.multiply(
+					GTUtility.convertRGBtoOpaqueRGBA_CL(material.materialRGB),
+					GTUtility.convertRGBtoOpaqueRGBA_CL(getPaintingColor()));
+			color = GTUtility.convertOpaqueRGBA_CLtoRGB(color);
+			return Pair.of(ClientHandler.METAL_CRATE.getParticleTexture(), color);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Similar to https://github.com/GregTechCE/GregTech/pull/1481 which is applied to the GTCE chest, this PR applies the same fix to the Gregicality Drum and Crate to prevent untextured/uncolored breaking particles.

Edit: Second commit is to fix Buffers having missing texture breaking particles, pointed out to me by Tech on discord