### PR TITLE
Fix Prospector Hard Crash

### DIFF
--- a/src/main/java/gregicadditions/GAConfig.java
+++ b/src/main/java/gregicadditions/GAConfig.java
@@ -1393,7 +1393,7 @@ public class GAConfig {
             @Config.RequiresMcRestart
             @Config.Name("Prospector scan cost")
             @Config.RangeInt(min = 0)
-            public int[] scanCosts = {32, 138, 8192, 32768};
+            public int[] scanCosts = {8, 32, 512, 2048};
 
             @Config.Comment("The radii in chunks the prospector will scan.")
             @Config.RequiresMcRestart

--- a/src/main/java/gregicadditions/item/behaviors/ProspectingToolBehaviour.java
+++ b/src/main/java/gregicadditions/item/behaviors/ProspectingToolBehaviour.java
@@ -66,7 +66,7 @@ public class ProspectingToolBehaviour implements IItemBehaviour, ItemUIFactory {
     protected final int tier;
 
 
-    public ProspectingToolBehaviour(int cost, int radius, int tier) {
+    public ProspectingToolBehaviour(int tier, int cost, int radius) {
         this.costs = cost;
         this.chunkRadius = radius;
         this.tier = tier;


### PR DESCRIPTION
Some of the parameters for the ProspectorStats constructor were out of order, leading to the scanCosts field being set to the chunk radius. This would cause the server instance of the world to get stuck trying to scan a chunk radius in the thousands, leading to a hard crash (and sometimes world corruption) on force close.

Additionally, I decreased the scanCosts even further since with default settings, the Prospector still could not be kept open for more than a few seconds from full charge with default settings.

Personally, I think that this highlights an issue of commits being applied directly to master. I think that we should have all code changes (except for the occasional compilation error fix) come through a PR first so that at least trivial typos can be caught by the rest of the development team.