### PR TITLE
Decrease minimum cracking unit casings

### DIFF
--- a/src/main/java/gregicadditions/machines/multi/override/MetaTileEntityCrackingUnit.java
+++ b/src/main/java/gregicadditions/machines/multi/override/MetaTileEntityCrackingUnit.java
@@ -144,7 +144,7 @@ public class MetaTileEntityCrackingUnit extends gregtech.common.metatileentities
                 .aisle("HCHCH", "HCHCH", "HCHCH")
                 .aisle("HCHCH", "H###H", "HCHCH")
                 .aisle("HCHCH", "HCOCH", "HCHCH")
-                .setAmountAtLeast('L', 20)
+                .setAmountAtLeast('L', 16)
                 .where('O', selfPredicate())
                 .where('L', statePredicate(getCasingState()))
                 .where('H', statePredicate(getCasingState()).or(abilityPartPredicate(ALLOWED_ABILITIES)))


### PR DESCRIPTION
This PR decreases the minimum required cracking unit casings to allow for more inputs and outputs on a single multiblock. Currently, you need to use many cracking units to automate a single gas centrifuge for nuclear products, which decentivizes the use of better coils in them. The changed amount allows for 4 fluid inputs and 4 fluid outputs as well as one energy hatch per multiblock at most. This allows all 3 outputs of the gas centrifuge to be processed inside a single multiblock with dedicated filtered output hatches, giving players better means to automating the process in its current state.