### PR TITLE
Fix Some Translation Issues in TOP

### DIFF
--- a/src/main/java/gregicadditions/theoneprobe/GADiodeProvider.java
+++ b/src/main/java/gregicadditions/theoneprobe/GADiodeProvider.java
@@ -29,10 +29,10 @@ public class GADiodeProvider extends ElectricContainerInfoProvider {
                 IProbeInfo horizontalPane = probeInfo.vertical(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
                 String transformInfo;
                 if (capability.inputsEnergy(sideHit)) {
-                    transformInfo = I18n.format("gtadditions.top.diode_input", inputAmperage);
+                    transformInfo = "{*gregtech.top.transform_input*} " + inputAmperage + "A";
                     horizontalPane.text(TextStyleClass.INFO + transformInfo);
                 } else if (capability.outputsEnergy(sideHit)) {
-                    transformInfo = I18n.format("gtadditions.top.diode_output", outputAmperage);
+                    transformInfo = "{*gregtech.top.transform_output*} " + outputAmperage + "A";
                     horizontalPane.text(TextStyleClass.INFO + transformInfo);
                 }
             }

--- a/src/main/java/gregicadditions/theoneprobe/GATransformerProvider.java
+++ b/src/main/java/gregicadditions/theoneprobe/GATransformerProvider.java
@@ -35,30 +35,25 @@ public class GATransformerProvider extends ElectricContainerInfoProvider {
                 String transformInfo;
 
                 // Step Up/Step Down line
-                String transformUpKey = "gregtech.top.transform_up";
-                String transformDownKey = "gregtech.top.transform_down";
                 if (mteTransformer.isInverted()) {
-                    transformInfo = I18n.format(transformUpKey,
-                            inputVoltageN, inputAmperage, outputVoltageN, outputAmperage);
+                    transformInfo = "{*gregtech.top.transform_up*} ";
                 } else {
-                    transformInfo = I18n.format(transformDownKey,
-                            inputVoltageN, inputAmperage, outputVoltageN, outputAmperage);
+                    transformInfo = "{*gregtech.top.transform_down*} ";
                 }
-
-                // Gets hit if our GT version is below 1.11.1
-                if (transformInfo.equals(transformUpKey)
-                        || transformInfo.equals(transformDownKey)) {
-                    return;
-                }
+                transformInfo += inputVoltageN + " (" + inputAmperage + "A) -> "
+                        + outputVoltageN + " (" + outputAmperage + "A)";
                 horizontalPane.text(TextStyleClass.INFO + transformInfo);
 
                 // Input/Output side line
                 horizontalPane = probeInfo.vertical(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
                 if (capability.inputsEnergy(sideHit)) {
-                    transformInfo = I18n.format("gregtech.top.transform_input", inputVoltageN, inputAmperage);
+                    transformInfo = "{*gregtech.top.transform_input*} "
+                            + inputVoltageN + " (" + inputAmperage + "A)";
                     horizontalPane.text(TextStyleClass.INFO + transformInfo);
-                } else if (capability.outputsEnergy(sideHit)) {
-                    transformInfo = I18n.format("gregtech.top.transform_output", outputVoltageN, outputAmperage);
+
+                } else if(capability.outputsEnergy(sideHit)) {
+                    transformInfo = "{*gregtech.top.transform_output*} "
+                            + outputVoltageN + " (" + outputAmperage + "A)";
                     horizontalPane.text(TextStyleClass.INFO + transformInfo);
                 }
             }

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -4124,8 +4124,6 @@ gtadditions.multiblock.steam_oven.description=A Multi Smelter at the Steam Age. 
 gtadditions.machine.diode.message=Max Amperage throughput: %s
 gtadditions.machine.diode.tooltip_general=A simple Diode that will allow Energy Flow in only one direction.
 gtadditions.machine.diode.tooltip_tool_usage=Hit with a Soft Hammer to toggle Amperage flow.
-gtadditions.top.diode_input=§6Input:§r %dA
-gtadditions.top.diode_output=§9Output:§r %dA
 
 gtadditions.machine.disassembler.lv.name=Basic Disassembler
 gtadditions.machine.disassembler.mv.name=Advanced Disassembler


### PR DESCRIPTION
This PR fixes an issue where the translation keys are not properly translated in TOP for the Diodes and Transformers. End result is no visible change, except that the text will display properly in TOP when the world is hosted on a server.