### PR TITLE
Add Disable to Distinct Buses Mode

### DIFF
--- a/src/main/java/gregicadditions/machines/multi/simple/LargeSimpleRecipeMapMultiblockController.java
+++ b/src/main/java/gregicadditions/machines/multi/simple/LargeSimpleRecipeMapMultiblockController.java
@@ -59,6 +59,8 @@ abstract public class LargeSimpleRecipeMapMultiblockController extends GARecipeM
      */
     protected boolean isDistinct = false;
 
+    protected final boolean canDistinct;
+
     DecimalFormat formatter = new DecimalFormat("#0.0");
 
     /**
@@ -75,6 +77,10 @@ abstract public class LargeSimpleRecipeMapMultiblockController extends GARecipeM
      * @param stack              should be between 0 ~ Integer.MAX_VALUE, Default should be 1
      */
     public LargeSimpleRecipeMapMultiblockController(ResourceLocation metaTileEntityId, RecipeMap<?> recipeMap, int EUtPercentage, int durationPercentage, int chancePercentage, int stack) {
+        this(metaTileEntityId, recipeMap, EUtPercentage, durationPercentage, chancePercentage, stack, true);
+    }
+
+    public LargeSimpleRecipeMapMultiblockController(ResourceLocation metaTileEntityId, RecipeMap<?> recipeMap, int EUtPercentage, int durationPercentage, int chancePercentage, int stack, boolean canDistinct) {
         super(metaTileEntityId, recipeMap);
         this.recipeMapWorkable = new LargeSimpleMultiblockRecipeLogic(this, EUtPercentage, durationPercentage, chancePercentage, stack);
 
@@ -82,6 +88,7 @@ abstract public class LargeSimpleRecipeMapMultiblockController extends GARecipeM
         this.durationPercentage = durationPercentage;
         this.chancePercentage = chancePercentage;
         this.stack = stack;
+        this.canDistinct = canDistinct;
     }
 
     @Override
@@ -232,14 +239,16 @@ abstract public class LargeSimpleRecipeMapMultiblockController extends GARecipeM
         super.addDisplayText(textList);
         textList.add(new TextComponentTranslation("gregtech.multiblock.universal.framework", this.maxVoltage));
 
-        ITextComponent buttonText = new TextComponentTranslation("gtadditions.multiblock.universal.distinct");
-        buttonText.appendText(" ");
-        ITextComponent button = withButton((isDistinct ?
-                new TextComponentTranslation("gtadditions.multiblock.universal.distinct.yes") :
-                new TextComponentTranslation("gtadditions.multiblock.universal.distinct.no")), "distinct");
-        withHoverTextTranslate(button, "gtadditions.multiblock.universal.distinct.info");
-        buttonText.appendSibling(button);
-        textList.add(buttonText);
+        if (canDistinct) {
+            ITextComponent buttonText = new TextComponentTranslation("gtadditions.multiblock.universal.distinct");
+            buttonText.appendText(" ");
+            ITextComponent button = withButton((isDistinct ?
+                    new TextComponentTranslation("gtadditions.multiblock.universal.distinct.yes") :
+                    new TextComponentTranslation("gtadditions.multiblock.universal.distinct.no")), "distinct");
+            withHoverTextTranslate(button, "gtadditions.multiblock.universal.distinct.info");
+            buttonText.appendSibling(button);
+            textList.add(buttonText);
+        }
     }
 
     @Override
@@ -306,7 +315,9 @@ abstract public class LargeSimpleRecipeMapMultiblockController extends GARecipeM
 
         @Override
         protected void trySearchNewRecipe() {
-            if (metaTileEntity instanceof LargeSimpleRecipeMapMultiblockController && ((LargeSimpleRecipeMapMultiblockController) metaTileEntity).isDistinct) {
+            if (metaTileEntity instanceof LargeSimpleRecipeMapMultiblockController) {
+                LargeSimpleRecipeMapMultiblockController controller = (LargeSimpleRecipeMapMultiblockController) metaTileEntity;
+                if (controller.canDistinct && controller.isDistinct)
                     trySearchNewRecipeDistinct();
             } else trySearchNewRecipeCombined();
         }

--- a/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargeChemicalReactor.java
+++ b/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargeChemicalReactor.java
@@ -28,7 +28,7 @@ public class TileEntityLargeChemicalReactor extends LargeSimpleRecipeMapMultiblo
 
 
 	public TileEntityLargeChemicalReactor(ResourceLocation metaTileEntityId) {
-		super(metaTileEntityId, GARecipeMaps.LARGE_CHEMICAL_RECIPES, GAConfig.multis.largeChemicalReactor.euPercentage, GAConfig.multis.largeChemicalReactor.durationPercentage, GAConfig.multis.largeChemicalReactor.chancedBoostPercentage, GAConfig.multis.largeChemicalReactor.stack);
+		super(metaTileEntityId, GARecipeMaps.LARGE_CHEMICAL_RECIPES, GAConfig.multis.largeChemicalReactor.euPercentage, GAConfig.multis.largeChemicalReactor.durationPercentage, GAConfig.multis.largeChemicalReactor.chancedBoostPercentage, GAConfig.multis.largeChemicalReactor.stack, false);
 	}
 
 	@Override

--- a/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargeMultiUse.java
+++ b/src/main/java/gregicadditions/machines/multi/simple/TileEntityLargeMultiUse.java
@@ -65,7 +65,7 @@ public class TileEntityLargeMultiUse extends LargeSimpleRecipeMapMultiblockContr
     private int pos;
 
     public TileEntityLargeMultiUse(ResourceLocation metaTileEntityId, RecipeMap<?> recipeMap) {
-        super(metaTileEntityId, recipeMap, GAConfig.multis.largeMultiUse.euPercentage, GAConfig.multis.largeMultiUse.durationPercentage, GAConfig.multis.largeMultiUse.chancedBoostPercentage, GAConfig.multis.largeMultiUse.stack);
+        super(metaTileEntityId, recipeMap, GAConfig.multis.largeMultiUse.euPercentage, GAConfig.multis.largeMultiUse.durationPercentage, GAConfig.multis.largeMultiUse.chancedBoostPercentage, GAConfig.multis.largeMultiUse.stack, false);
         this.recipeMap = recipeMap;
         pos = Arrays.asList(possibleRecipe).indexOf(recipeMap);
     }


### PR DESCRIPTION
This PR allows for multiblocks that extend `LargeSimpleRecipeMapMultiblockController` to disable the Distinct Buses feature entirely. This was done for:
- The LCR, since it really doesn't make sense for that machine
- The Multi-Use, since it has some issues with the feature causing crashes, so it will be disabled for now for the 0.22 release until a better fix is found