### PR TITLE
Add Tooltip Override for Removed Materials

### DIFF
--- a/src/main/java/gregicadditions/CommonProxy.java
+++ b/src/main/java/gregicadditions/CommonProxy.java
@@ -18,11 +18,13 @@ import gregicadditions.worldgen.PumpjackHandler;
 import gregicadditions.worldgen.StoneGenEvents;
 import gregicadditions.worldgen.WorldGenRegister;
 import gregtech.api.unification.ore.OrePrefix;
+import gregtech.api.util.FluidTooltipUtil;
 import gregtech.common.blocks.VariantItemBlock;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Config;
 import net.minecraftforge.common.config.ConfigManager;
@@ -60,10 +62,18 @@ public class CommonProxy {
     public void onLoad() throws IOException {
         if (GAConfig.Misc.reverseAfterCT)
             registerRecipesAfterCT();
+        setRemovedMaterialTooltips();
         WorldGenRegister.init();
         if (GAConfig.Misc.multiStoneGen) {
             MinecraftForge.EVENT_BUS.register(new StoneGenEvents());
         }
+    }
+
+    // This method is used to set tooltips for materials to be removed in the future.
+    // If we want to staggered-remove a material, apply a warning to it here.
+    private static final String REMOVED_MAT_TOOLTIP = TextFormatting.RED + "This Material will be removed in next release!";
+    private static void setRemovedMaterialTooltips() {
+        FluidTooltipUtil.registerTooltip(GAMaterials.NitrogenTetroxide.getMaterialFluid(), REMOVED_MAT_TOOLTIP);
     }
 
     @SubscribeEvent


### PR DESCRIPTION
This PR simply adds a mechanism for applying a "to be removed" tooltip to materials we will be removing in future releases.

![image](https://user-images.githubusercontent.com/10861407/116611526-1572c480-a8fc-11eb-8530-a35ce3796956.png)

This is useful when we want to remove a material, but do not want to just delete the material from all player's worlds. This tooltip will make it clear to the player that the material can no longer be produced and should be used up before the release following.

This applies to items and fluids, though currently we are only doing it for 1 fluid material. For Simple Materials, we can just apply the tooltip to the material itself since it accepts a String tooltip, but GTCE materials do not so it has to be done this way.