### PR TITLE
Buff Poor Ores

### DIFF
--- a/src/main/java/gregicadditions/recipes/OreRecipeHandler.java
+++ b/src/main/java/gregicadditions/recipes/OreRecipeHandler.java
@@ -126,13 +126,13 @@ public class OreRecipeHandler {
         if (!crushedStack.isEmpty()) {
             RecipeMaps.FORGE_HAMMER_RECIPES.recipeBuilder()
                     .input(orePrefix, material)
-                    .chancedOutput(GTUtility.copyAmount((int) Math.ceil(amountOfCrushedOre), crushedStack), 5000, 0)
+                    .outputs(GTUtility.copyAmount((int) Math.ceil(amountOfCrushedOre), crushedStack))
                     .duration(100).EUt(6)
                     .buildAndRegister();
 
             RecipeBuilder<?> builder = RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
                     .input(orePrefix, material)
-                    .chancedOutput(GTUtility.copyAmount((int) Math.round(amountOfCrushedOre), crushedStack), 5000, 0)
+                    .outputs(GTUtility.copyAmount((int) Math.round(amountOfCrushedOre), crushedStack))
                     .chancedOutput(byproductStack, 700, 425)
                     .duration(400).EUt(12);
             for (MaterialStack secondaryMaterial : orePrefix.secondaryMaterials) {


### PR DESCRIPTION
This PR changes Poor Ores to no longer use chanced outputs on the crushed output. Currently, Poor Ores are next to useless as a result of the chanced nature, and are better furnace smelted than processed any further. This PR addresses this by changing the output type to a regular output. 