### PR TITLE
Add Tooltip Ability to Simple Fluids in CT

### DIFF
--- a/src/main/java/gregicadditions/integrations/crafttweaker/CTUtils.java
+++ b/src/main/java/gregicadditions/integrations/crafttweaker/CTUtils.java
@@ -17,6 +17,7 @@ import gregtech.api.unification.material.MaterialIconSet;
 import gregtech.api.unification.ore.OrePrefix;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
+import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
@@ -97,8 +98,8 @@ public class CTUtils {
     }
 
     @ZenMethod("registerFluid")
-    public static void registerFluid(String name, int rgb) {
-        new SimpleFluidMaterial(name, rgb);
+    public static void registerFluid(String name, int rgb, @Optional String tooltip) {
+        new SimpleFluidMaterial(name, rgb, tooltip);
     }
 
     @ZenMethod


### PR DESCRIPTION
This PR very simply allows for an `@Optional String` to be passed in the `registerFluid` CTUtils method, so that modpack makers can utilize our Fluid Tooltip system when adding new Simple Fluids. Since it is marked as `optional`, it will not break any existing scripts, and modpack authors simply have to add a String after the name and rgb values where they make fluids already.