### PR TITLE
Remove ForgeMultiPart Dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,14 +95,13 @@ repositories {
 
 dependencies {
 
-    // These 8 will always be in game
+    // These 7 will always be in game
     "deobfCompile"("gregtechce:gregtech:$mcVersion:${config["gregtech.version"]}")
     "deobfCompile"("codechicken-lib-1-8:CodeChickenLib-$mcVersion:${config["ccl.version"]}:universal")
     "deobfCompile"("codechicken:ChickenASM:$shortVersion-${config["chickenasm.version"]}")
     "deobfCompile"("mezz.jei:jei_$mcVersion:${config["jei.version"]}")
     "deobfCompile"("mcjty.theoneprobe:TheOneProbe-$shortVersion:$shortVersion-${config["top.version"]}")
     "deobfCompile"("CraftTweaker2:CraftTweaker2-MC$strippedVersion-Main:${config["crafttweaker.version"]}")
-    "deobfCompile"("forge-multipart-cbe:ForgeMultipart-$mcVersion:${config["fmp.version"]}:universal")
     "deobfCompile"("team.chisel.ctm:CTM:MC$mcVersion-${config["ctm.version"]}")
 
     // Change to "deobfCompile" to add one of these to game

--- a/build.properties
+++ b/build.properties
@@ -10,7 +10,6 @@ jei.version=4.15.0.291
 forestry.version=5.8.2.387
 ccl.version=3.2.3.358
 chickenasm.version=1.0.2.9
-fmp.version=2.6.2.83
 mantle.version=1.3.3.42
 ticon.version=2.12.0.115
 ctm.version=1.0.2.31


### PR DESCRIPTION
This PR removes ForgeMultiPart as a dependency from our project completely. We are not using it at all, and GTCE was using it for legacy support for versions older than August 2019. GTCE removed the dependency here: https://github.com/GregTechCE/GregTech/pull/1594, so we may as well do the same.