### PR TITLE
Fix some loose ends with PlatLine

### DIFF
--- a/src/main/java/gregicadditions/GAMaterials.java
+++ b/src/main/java/gregicadditions/GAMaterials.java
@@ -1655,6 +1655,9 @@ public class GAMaterials implements IMaterialHandler {
         IrOsLeachResidue.washedIn = SodiumPersulfate;
         IrLeachResidue.addOreByProducts(PlatinumMetallicPowder, IrOsLeachResidue);
         IrLeachResidue.washedIn = SodiumPersulfate;
+        Cooperite.oreByProducts.clear();
+        Cooperite.addOreByProducts(PalladiumMetallicPowder, Nickel, IrLeachResidue);
+        Cooperite.disableDirectSmelting = true; // TODO Change to 2 PMP if GTCE ever allows for DustMaterial and multiple-output directSmelting
     }
 
 

--- a/src/main/java/gregicadditions/recipes/categories/RecipeOverride.java
+++ b/src/main/java/gregicadditions/recipes/categories/RecipeOverride.java
@@ -696,9 +696,9 @@ public class RecipeOverride {
                 .output(dust, SiliconDioxide)
                 .output(dust, PreciousMetal)
                 .output(dust, PlatinumMetallicPowder, 2)
-                .chancedOutput(OreDictUnifier.get(dustTiny, PalladiumMetallicPowder, 6), 95, 0)
-                .chancedOutput(OreDictUnifier.get(dustTiny, IrLeachResidue, 3), 90, 0)
-                .chancedOutput(OreDictUnifier.get(dustTiny, IrOsLeachResidue, 3), 85, 0)
+                .chancedOutput(OreDictUnifier.get(dustTiny, PalladiumMetallicPowder, 6), 9500, 0)
+                .chancedOutput(OreDictUnifier.get(dustTiny, IrLeachResidue, 3), 9000, 0)
+                .chancedOutput(OreDictUnifier.get(dustTiny, IrOsLeachResidue, 3), 8500, 0)
                 .buildAndRegister();
 
         // Sheldonite Smelting Recipe

--- a/src/main/java/gregicadditions/recipes/categories/RecipeOverride.java
+++ b/src/main/java/gregicadditions/recipes/categories/RecipeOverride.java
@@ -688,6 +688,42 @@ public class RecipeOverride {
                 .input(dustSmall, GalliumArsenide)
                 .outputs(SILICON_BOULE.getStackForm())
                 .buildAndRegister();
+
+        // BartWorks Platinum Group Sludge
+        removeRecipesByInputs(CENTRIFUGE_RECIPES, OreDictUnifier.get(dust, PlatinumGroupSludge));
+        CENTRIFUGE_RECIPES.recipeBuilder().EUt(30).duration(900)
+                .input(dust, PlatinumGroupSludge)
+                .output(dust, SiliconDioxide)
+                .output(dust, PreciousMetal)
+                .output(dust, PlatinumMetallicPowder, 2)
+                .chancedOutput(OreDictUnifier.get(dustTiny, PalladiumMetallicPowder, 6), 95, 0)
+                .chancedOutput(OreDictUnifier.get(dustTiny, IrLeachResidue, 3), 90, 0)
+                .chancedOutput(OreDictUnifier.get(dustTiny, IrOsLeachResidue, 3), 85, 0)
+                .buildAndRegister();
+
+        // Sheldonite Smelting Recipe
+        removeFurnaceRecipe(OreDictUnifier.get(dust, Cooperite));
+        ModHandler.addSmeltingRecipe(OreDictUnifier.get(dust, Cooperite), OreDictUnifier.get(dust, PlatinumMetallicPowder, 2));
+
+        // Sheldonite Electrolysis
+        removeRecipesByInputs(ELECTROLYZER_RECIPES, OreDictUnifier.get(dust, Cooperite, 6));
+        ELECTROLYZER_RECIPES.recipeBuilder().EUt(60).duration(2592)
+                .input(dust, Cooperite, 6)
+                .output(dust, PlatinumMetallicPowder, 6)
+                .output(dust, Nickel)
+                .output(dust, Sulfur)
+                .output(dust, PalladiumMetallicPowder, 2)
+                .buildAndRegister();
+
+        // Endstone
+        removeRecipesByInputs(CENTRIFUGE_RECIPES, OreDictUnifier.get(dust, Endstone));
+        CENTRIFUGE_RECIPES.recipeBuilder().EUt(20).duration(320)
+                .input(dust, Endstone)
+                .chancedOutput(OreDictUnifier.get(dustSmall, Tungstate), 1250, 450)
+                .chancedOutput(OreDictUnifier.get(dustTiny, PlatinumMetallicPowder, 2), 625, 150)
+                .chancedOutput(new ItemStack(Blocks.SAND), 9000, 300)
+                .fluidOutputs(Helium.getFluid(120))
+                .buildAndRegister();
     }
 
     private static void vanillaOverride() {
@@ -836,12 +872,6 @@ public class RecipeOverride {
     }
 
     private static void recipeRemoval() {
-
-        // Remove GTCE Platinum and Palladium Recipes
-        removeRecipesByInputs(CHEMICAL_RECIPES, new ItemStack[]{OreDictUnifier.get(crushedPurified, Chalcopyrite)}, new FluidStack[]{NitricAcid.getFluid(1000)});
-        removeRecipesByInputs(CHEMICAL_RECIPES, new ItemStack[]{OreDictUnifier.get(crushedPurified, Pentlandite)},  new FluidStack[]{NitricAcid.getFluid(1000)});
-        removeRecipesByInputs(CENTRIFUGE_RECIPES, OreDictUnifier.get(dust, PlatinumGroupSludge));
-        removeRecipesByInputs(CENTRIFUGE_RECIPES, OreDictUnifier.get(dust, Endstone));
 
         // Remove Conflicting Redstone Plate Recipe
         removeRecipesByInputs(COMPRESSOR_RECIPES, OreDictUnifier.get(dust, Redstone));


### PR DESCRIPTION
I made a few small changes to balance the platinum group process a little better, mostly adapted from Bartworks.

- Sheldonite Ore no longer smelts into Platinum Ingots, it no longer has direct Platinum and Iridium byproducts, and no longer electrolyzes to Platinum and Iridium. Instead, these have been replaced with Platinum Metallic Powder and Iridium Leach in all cases, and had their output amounts doubled. This is consistent with Bartworks' implementation, as this ore was very overpowered and game breaking. If an ore like this is desired, there is still Platinum Ore, Iridium Ore, etc..

- I re-enabled Platinum Group Sludge from GTCE. I updated it similarly to how it is handled by Bartworks, and now instead have it output the various Platgroup starting points, and double their outputs. This is a very primitive way for a player to approach the platline, and gives a very early game option to get very tiny amounts of Platgroup Metals from Chalcopyrite and Pentlandite

- I re-enabled Endstone electrolysis, with a 6.25% chance for 2 Tiny Piles of Platinum Metallic Powder. This brings back a very good source of Plat metallic powder, Tungstate, and Helium that before we were just removing.

All in all, these changes are all quite minor, but give the player more options with how to progress. I think that this is a good way to design our progression, so I think these recipes are very good additions.