### PR TITLE
Update to GTCE 1.15.0

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -4,7 +4,7 @@ mc.version=1.12.2
 forge.version=14.23.5.2847
 mcp.version=stable_39
 
-gregtech.version=1.14.0.689
+gregtech.version=1.15.0.721
 crafttweaker.version=1.12-4.1.20.554
 jei.version=4.15.0.291
 forestry.version=5.8.2.387

--- a/src/main/java/gregicadditions/Gregicality.java
+++ b/src/main/java/gregicadditions/Gregicality.java
@@ -35,7 +35,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import java.io.IOException;
 
 @Mod(modid = Gregicality.MODID, name = Gregicality.NAME, version = Gregicality.VERSION,
-        dependencies = "required-after:gregtech@[1.14.0.689,);" +
+        dependencies = "required-after:gregtech@[1.15.0.721,);" +
                 "after:forestry;" +
                 "after:tconstruct;" +
                 "after:exnihilocreatio;" +

--- a/src/main/java/gregicadditions/item/behaviors/monitorPlugin/FakeGuiPluginBehavior.java
+++ b/src/main/java/gregicadditions/item/behaviors/monitorPlugin/FakeGuiPluginBehavior.java
@@ -20,6 +20,8 @@ import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.api.multiblock.PatternMatchContext;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.Slot;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.tileentity.TileEntity;
@@ -113,8 +115,8 @@ public class FakeGuiPluginBehavior extends ProxyHolderPluginBehavior {
             boolean hasPlayerInventory = false;
             for (Widget widget : ui.guiWidgets.values()) {
                 if (widget instanceof SlotWidget) {
-                    SlotItemHandler handler = ((SlotWidget) widget).getHandle();
-                    if (handler.getItemHandler() instanceof PlayerMainInvWrapper) {
+                    IInventory handler = ((SlotWidget) widget).getHandle().inventory;
+                    if (handler instanceof PlayerMainInvWrapper) {
                         hasPlayerInventory = true;
                         continue;
                     }

--- a/src/main/java/gregicadditions/recipes/compat/jei/GARecipeMapCategory.java
+++ b/src/main/java/gregicadditions/recipes/compat/jei/GARecipeMapCategory.java
@@ -22,6 +22,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.items.ItemStackHandler;
+import net.minecraftforge.items.SlotItemHandler;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
@@ -82,14 +83,18 @@ public class GARecipeMapCategory implements IRecipeCategory<GARecipeWrapper> {
 
             if (uiWidget instanceof SlotWidget) {
                 SlotWidget slotWidget = (SlotWidget) uiWidget;
-                if (slotWidget.getHandle().getItemHandler() == importItems) {
+                if (!(slotWidget.getHandle() instanceof SlotItemHandler)) {
+                    continue;
+                }
+                SlotItemHandler handle = (SlotItemHandler) slotWidget.getHandle();
+                if (handle.getItemHandler() == importItems) {
                     //this is input item stack slot widget, so add it to item group
-                    itemStackGroup.init(slotWidget.getHandle().getSlotIndex(), true,
+                    itemStackGroup.init(handle.getSlotIndex(), true,
                             slotWidget.getPosition().x,
                             slotWidget.getPosition().y);
-                } else if (slotWidget.getHandle().getItemHandler() == exportItems) {
+                } else if (handle.getItemHandler() == exportItems) {
                     //this is output item stack slot widget, so add it to item group
-                    itemStackGroup.init(importItems.getSlots() + slotWidget.getHandle().getSlotIndex(), false,
+                    itemStackGroup.init(importItems.getSlots() + handle.getSlotIndex(), false,
                             slotWidget.getPosition().x,
                             slotWidget.getPosition().y);
                 }

--- a/src/main/java/gregicadditions/recipes/compat/jei/GARecipeWrapper.java
+++ b/src/main/java/gregicadditions/recipes/compat/jei/GARecipeWrapper.java
@@ -4,6 +4,7 @@ import gregicadditions.GAValues;
 import gregtech.api.recipes.CountableIngredient;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.Recipe.ChanceEntry;
+import gregtech.api.recipes.recipeproperties.RecipeProperty;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.util.ItemStackHashStrategy;
 import it.unimi.dsi.fastutil.Hash;
@@ -128,14 +129,12 @@ public class GARecipeWrapper implements IRecipeWrapper {
         minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.total", Math.abs((long) recipe.getEUt()) * recipe.getDuration()), 0, yPosition, 0x111111);
         minecraft.fontRenderer.drawString(I18n.format(recipe.getEUt() >= 0 ? "gregtech.recipe.eu" : "gregtech.recipe.eu_inverted", Math.abs(recipe.getEUt()), getMinTierForVoltage(recipe.getEUt())), 0, yPosition += lineHeight, 0x111111);
         minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.duration", recipe.getDuration() / 20f), 0, yPosition += lineHeight, 0x111111);
-        for (String propertyKey : recipe.getPropertyKeys()) {
-            minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe." + propertyKey,
-                    recipe.<Object>getProperty(propertyKey)), 0, yPosition += lineHeight, 0x111111);
-        }
+        for (Map.Entry<RecipeProperty<?>, Object> propertyEntry : recipe.getRecipePropertyStorage().getRecipeProperties())
+            propertyEntry.getKey().drawInfo(minecraft, 0, yPosition += lineHeight, 0x111111, propertyEntry.getValue());
     }
 
     private int getPropertyListHeight() {
-        return (recipe.getPropertyKeys().size() + 3) * lineHeight;
+        return (recipe.getRecipePropertyStorage().getSize() + 3) * lineHeight;
     }
 
 

--- a/src/main/java/gregicadditions/recipes/impl/LargeRecipeBuilder.java
+++ b/src/main/java/gregicadditions/recipes/impl/LargeRecipeBuilder.java
@@ -1,6 +1,5 @@
 package gregicadditions.recipes.impl;
 
-import com.google.common.collect.ImmutableMap;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
@@ -55,6 +54,6 @@ public class LargeRecipeBuilder extends RecipeBuilder<LargeRecipeBuilder> {
     public ValidationResult<Recipe> build() {
         return ValidationResult.newResult(finalizeAndValidate(),
                 new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs,
-                        ImmutableMap.of(), duration, EUt, hidden));
+                        duration, EUt, hidden));
     }
 }

--- a/src/main/java/gregicadditions/widgets/WidgetOreList.java
+++ b/src/main/java/gregicadditions/widgets/WidgetOreList.java
@@ -164,8 +164,8 @@ public class WidgetOreList extends ScrollableListWidget {
                         if (tick % 20 == 0) {
                             List<ItemStack> list = OreDictUnifier.getAllWithOreDictionaryName(widgetMap.get(widget));
                             if (list.size() > 0 ) {
-                                slotWidget.getHandle().getItemHandler().extractItem(0,64, false);
-                                slotWidget.getHandle().getItemHandler().insertItem(0, list.get(Math.floorMod(tick / 20, list.size())), false);
+                                slotWidget.getHandle().decrStackSize(64);
+                                slotWidget.getHandle().putStack(list.get(Math.floorMod(tick / 20, list.size())));
                             }
                         }
                         slotWidget.setEnabled(widget.getPosition().y >= this.getPosition().y - 9 && widget.getPosition().y <= this.getPosition().y + this.getSize().height - 9);


### PR DESCRIPTION
The update to GTCE 1.15.0 introduced a number of breaking changes, first being https://github.com/GregTechCE/GregTech/pull/1485 which required some updates to our Widget use.
- I updated the `FakeGuiPluginBehavior` class code that was checking for if a Slot belonged to a player inventory. This part needs to be tested as I did not know how to test it, but I am confident it will work
- I updated `GARecipeMapCategory` which simply needed to reorganize its checks a bit. This code was updated identically to similar code in GTCE
- I updated `WidgetOreList` code which was updating the ItemStack in a Slot. Based on testing with the Prospector, I believe this all works perfectly but since I did not write this code, I'm not certain I tested the change. However I am again confident that it is good

Second breaking change was https://github.com/GregTechCE/GregTech/pull/1580 which required updates to our JEI code and Recipe Builders.
- I updated `GARecipeWrapper` to use the new property system when applying property information to JEI recipes. This is identical to a change made in GTCE.
- I updated `LargeRecipeBuilder` to no longer use a deprecated method. Our other builders should update similarly, but we will not have issues with leaving them as-is, we will just be missing out on this feature.

In total, there were 3 game-breaking issues fixed, being:
- Our (and all of GTCE's) recipe map categories in JEI were broken, showed no recipes and caused spam in the log
- Our Prospectors would crash the game when the GUI was opened
- The Central Monitor in the GUI proxy mode would crash the game

Lastly, I set our minimum version of GTCE to 1.15.0, as with any lower, these above issues would return.