### PR TITLE
Quick fix for Tinkers warning

### DIFF
--- a/src/main/java/gregicadditions/integrations/tconstruct/FluidTemp.java
+++ b/src/main/java/gregicadditions/integrations/tconstruct/FluidTemp.java
@@ -6,8 +6,10 @@ import gregtech.api.unification.material.type.IngotMaterial;
 import gregtech.api.unification.material.type.Material;
 
 @IMaterialHandler.RegisterMaterialHandler
-public class FluidTemp {
-	static {
+public class FluidTemp implements IMaterialHandler {
+
+	@Override
+	public void onMaterialsInit() {
 		for (Material mat : Material.MATERIAL_REGISTRY)
 			if (mat instanceof DustMaterial && (mat instanceof IngotMaterial || mat.hasFlag(DustMaterial.MatFlags.SMELT_INTO_FLUID))) {
 				if (mat instanceof IngotMaterial && ((IngotMaterial) mat).blastFurnaceTemperature > 0) ((IngotMaterial) mat).setFluidTemperature(((IngotMaterial) mat).blastFurnaceTemperature);


### PR DESCRIPTION
A quick fix for this tinkers warning seen in the log, 

```less
[12:59:10] [Client thread/ERROR]: Failed to load material handler class gregicadditions.integrations.tconstruct.FluidTemp from Gregicality-1.12.2-0.22.3.1.jar: class does not implement IMaterialHandler
[12:59:10] [Client thread/ERROR]: Consult the mod author for fix on his side.
```

This fix is basically just copying what was done here, <https://github.com/Shadows-of-Fire/Shadows-of-Greg/commit/f40d47768b4f5e9d55fc8bd0b9526444df030a05>