### PR TITLE
Fix Nuclear Fluorine

### DIFF
--- a/src/main/java/gregicadditions/recipes/GARecipeMaps.java
+++ b/src/main/java/gregicadditions/recipes/GARecipeMaps.java
@@ -210,7 +210,7 @@ public class GARecipeMaps {
 
     @ZenProperty
     public static final RecipeMap<IntCircuitRecipeBuilder> GAS_CENTRIFUGE_RECIPES = new RecipeMap<>("gas_centrifuge",
-            1, 1, 0, 0, 1, 1, 1, 3, new IntCircuitRecipeBuilder())
+            0, 1, 0, 0, 1, 1, 1, 3, new IntCircuitRecipeBuilder())
             .setSlotOverlay(false, false, GuiTextures.CIRCUIT_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_BATH, ProgressWidget.MoveType.VERTICAL_INVERTED);
 

--- a/src/main/java/gregicadditions/recipes/categories/CasingRecipes.java
+++ b/src/main/java/gregicadditions/recipes/categories/CasingRecipes.java
@@ -125,7 +125,7 @@ public class CasingRecipes {
                 .input(plate, IncoloyMA956, 8)
                 .input(cableGtOctal, Platinum)
                 .inputs(MetaTileEntities.HULL[LuV].getStackForm())
-                .fluidInputs(Uranium235.getFluid(L * 10))
+                .fluidInputs(Uranium238Isotope.getMaterial().getFluid(L * 10))
                 .outputs(GAMetaBlocks.MUTLIBLOCK_CASING.getItemVariant(TIERED_HULL_LUV))
                 .buildAndRegister();
 
@@ -135,7 +135,7 @@ public class CasingRecipes {
                 .input(plate, BabbittAlloy, 8)
                 .input(cableGtOctal, NiobiumTitanium)
                 .inputs(MetaTileEntities.HULL[GAValues.ZPM].getStackForm())
-                .fluidInputs(Plutonium241.getFluid(L * 10))
+                .fluidInputs(Plutonium244Isotope.getMaterial().getFluid(L * 10))
                 .outputs(GAMetaBlocks.MUTLIBLOCK_CASING.getItemVariant(TIERED_HULL_ZPM))
                 .buildAndRegister();
 

--- a/src/main/java/gregicadditions/recipes/categories/handlers/NuclearHandler.java
+++ b/src/main/java/gregicadditions/recipes/categories/handlers/NuclearHandler.java
@@ -233,8 +233,8 @@ public class NuclearHandler {
             radioactiveMaterial.composition.forEach((key, value) -> builder1.fluidOutputs(key.getFluidHexafluoride(value * 2)));
             builder1.buildAndRegister();
 
-            // [Mat + F6] + 2H2O -> [Mat + F6 + 2H2O]
             radioactiveMaterial.composition.forEach((key, value) -> {
+                // [Mat + F6] + 2H2O -> [Mat + F6 + 2H2O]
                 CRACKING_RECIPES.recipeBuilder().duration(40 * complexity / 100).EUt(120)
                         .fluidInputs(Steam.getFluid(2000))
                         .fluidInputs(key.getFluidHexafluoride(1000))

--- a/src/main/java/gregicadditions/recipes/categories/handlers/NuclearHandler.java
+++ b/src/main/java/gregicadditions/recipes/categories/handlers/NuclearHandler.java
@@ -124,7 +124,7 @@ public class NuclearHandler {
                 .buildAndRegister();
 
         // [Fuel + C] + 4O = CO2 + [Fuel + 2O]
-        BLAST_RECIPES.recipeBuilder().blastFurnaceTemp(1000).EUt(120).duration(3000)
+        BLAST_RECIPES.recipeBuilder().blastFurnaceTemp(1000).EUt(120).duration(2000)
                 .inputs(isotopeMaterial.getItemStack(GAEnums.GAOrePrefix.carbide, 1))
                 .fluidInputs(Oxygen.getFluid(4000))
                 .fluidOutputs(CarbonDioxide.getFluid(1000))
@@ -198,108 +198,60 @@ public class NuclearHandler {
         if (radioactiveMaterial != null && radioactiveMaterial.composition.size() > 0) {
             int complexity = radioactiveMaterial.complexity;
 
-            // Mat + 2HNO3 = [Mat + 2NO2] + H2O2
-            CHEMICAL_RECIPES.recipeBuilder().duration(2000 * complexity / 100)
+            // Mat + 2HNO3 = [Mat + 2NO3] + 2H
+            CHEMICAL_RECIPES.recipeBuilder().duration(200 * complexity / 100)
                     .input(dust, radioactiveMaterial.getMaterial())
                     .fluidInputs(NitricAcid.getFluid(2000))
                     .outputs(radioactiveMaterial.getItemStack(GAEnums.GAOrePrefix.nitrite, 3))
+                    .fluidOutputs(Hydrogen.getFluid(2000))
                     .buildAndRegister();
 
-            // [Mat + 2NO2] = [Mat + 2O] + N2O4
-            BLAST_RECIPES.recipeBuilder().blastFurnaceTemp(600).duration(100 * complexity / 100).EUt(120 * complexity / 100)
+            // [Mat + 2NO3] = [Mat + 2O] + 2NO
+            BLAST_RECIPES.recipeBuilder().blastFurnaceTemp(600).duration(90 * complexity / 100).EUt(120)
                     .inputs(radioactiveMaterial.getItemStack(GAEnums.GAOrePrefix.nitrite, 3))
                     .outputs(radioactiveMaterial.getItemStack(GAEnums.GAOrePrefix.dioxide, 1))
-                    .fluidOutputs(DinitrogenTetroxide.getFluid(1000))
+                    .fluidOutputs(NitricOxide.getFluid(2000))
                     .buildAndRegister();
 
             // [Mat + 2O] + 6Cl = [Mat + 6Cl] + 2O
             CHEMICAL_RECIPES.recipeBuilder().duration(1000 * complexity / 100)
                     .inputs(radioactiveMaterial.getItemStack(GAEnums.GAOrePrefix.dioxide, 1))
                     .fluidInputs(Chlorine.getFluid(6000))
-                    .fluidOutputs(radioactiveMaterial.getFluidHexachloride(6000))
+                    .fluidOutputs(radioactiveMaterial.getFluidHexachloride(1000))
                     .fluidOutputs(Oxygen.getFluid(2000))
                     .buildAndRegister();
 
-            // [Mat + 6Cl] + 6HF = 6HCl + [Mat + 6F] (keeping two multiplier for game balance right now)
-            CHEMICAL_RECIPES.recipeBuilder().duration(1000 * complexity / 100)
-                    .fluidInputs(radioactiveMaterial.getFluidHexachloride(2000))
-                    .fluidInputs(HydrofluoricAcid.getFluid(10000))
-                    .fluidOutputs(HydrochloricAcid.getFluid(10000))
-                    .fluidOutputs(radioactiveMaterial.getFluidHexafluoride(2000))
+            // [Mat + 6Cl] + 6HF = 6HCl + [Mat + 6F]
+            CHEMICAL_RECIPES.recipeBuilder().duration(100 * complexity / 100)
+                    .fluidInputs(radioactiveMaterial.getFluidHexachloride(1000))
+                    .fluidInputs(HydrofluoricAcid.getFluid(6000))
+                    .fluidOutputs(HydrochloricAcid.getFluid(6000))
+                    .fluidOutputs(radioactiveMaterial.getFluidHexafluoride(1000))
                     .buildAndRegister();
 
-            IntCircuitRecipeBuilder builder1 = GAS_CENTRIFUGE_RECIPES.recipeBuilder().duration(500 * complexity / 100).circuitMeta(0).EUt(GAValues.V[GAValues.ULV]).fluidInputs(radioactiveMaterial.getFluidHexafluoride(20000));
+            IntCircuitRecipeBuilder builder1 = GAS_CENTRIFUGE_RECIPES.recipeBuilder().duration(500 * complexity / 100).EUt(960).fluidInputs(radioactiveMaterial.getFluidHexafluoride(20000));
             radioactiveMaterial.composition.forEach((key, value) -> builder1.fluidOutputs(key.getFluidHexafluoride(value * 2)));
             builder1.buildAndRegister();
 
-            IntCircuitRecipeBuilder builder2 = GAS_CENTRIFUGE_RECIPES.recipeBuilder().duration(500 * complexity / 100).circuitMeta(1).EUt(GAValues.V[GAValues.LV]).fluidInputs(radioactiveMaterial.getFluidHexafluoride(20000));
-            radioactiveMaterial.composition.forEach((key, value) -> builder2.fluidOutputs(key.getFluidHexafluoride((value >= 5000 ? value : value >= 1000 ? value * 110 / 100 : value * 2) * 2)));
-            builder2.buildAndRegister();
-
-            IntCircuitRecipeBuilder builder3 = GAS_CENTRIFUGE_RECIPES.recipeBuilder().duration(500 * complexity / 100).circuitMeta(2).EUt(GAValues.V[GAValues.MV]).fluidInputs(radioactiveMaterial.getFluidHexafluoride(20000));
-            radioactiveMaterial.composition.forEach((key, value) -> builder3.fluidOutputs(key.getFluidHexafluoride((value >= 5000 ? value : value >= 1000 ? value * 120 / 100 : value * 3) * 2)));
-            builder3.buildAndRegister();
-
-            IntCircuitRecipeBuilder builder4 = GAS_CENTRIFUGE_RECIPES.recipeBuilder().duration(500 * complexity / 100).circuitMeta(3).EUt(GAValues.V[GAValues.HV]).fluidInputs(radioactiveMaterial.getFluidHexafluoride(20000));
-            radioactiveMaterial.composition.forEach((key, value) -> builder4.fluidOutputs(key.getFluidHexafluoride((value >= 5000 ? value : value >= 1000 ? value * 130 / 100 : value * 4) * 2)));
-            builder4.buildAndRegister();
-
-            IntCircuitRecipeBuilder builder5 = GAS_CENTRIFUGE_RECIPES.recipeBuilder().duration(500 * complexity / 100).circuitMeta(4).EUt(GAValues.V[GAValues.EV]).fluidInputs(radioactiveMaterial.getFluidHexafluoride(20000));
-            radioactiveMaterial.composition.forEach((key, value) -> builder5.fluidOutputs(key.getFluidHexafluoride((value >= 5000 ? value : value >= 1000 ? value * 140 / 100 : value * 5) * 2)));
-            builder5.buildAndRegister();
-
-            IntCircuitRecipeBuilder builder6 = GAS_CENTRIFUGE_RECIPES.recipeBuilder().duration(500 * complexity / 100).circuitMeta(5).EUt(GAValues.V[GAValues.IV]).fluidInputs(radioactiveMaterial.getFluidHexafluoride(20000));
-            radioactiveMaterial.composition.forEach((key, value) -> builder6.fluidOutputs(key.getFluidHexafluoride((value >= 5000 ? value : value >= 1000 ? value * 150 / 100 : value * 6) * 2)));
-            builder6.buildAndRegister();
-
-            IntCircuitRecipeBuilder builder7 = GAS_CENTRIFUGE_RECIPES.recipeBuilder().duration(500 * complexity / 100).circuitMeta(6).EUt(GAValues.V[GAValues.LuV]).fluidInputs(radioactiveMaterial.getFluidHexafluoride(20000));
-            radioactiveMaterial.composition.forEach((key, value) -> builder7.fluidOutputs(key.getFluidHexafluoride((value >= 5000 ? value : value >= 1000 ? value * 160 / 100 : value * 7) * 2)));
-            builder7.buildAndRegister();
-
-            IntCircuitRecipeBuilder builder8 = GAS_CENTRIFUGE_RECIPES.recipeBuilder().duration(500 * complexity / 100).circuitMeta(7).EUt(GAValues.V[GAValues.ZPM]).fluidInputs(radioactiveMaterial.getFluidHexafluoride(20000));
-            radioactiveMaterial.composition.forEach((key, value) -> builder8.fluidOutputs(key.getFluidHexafluoride((value >= 5000 ? value : value >= 1000 ? value * 170 / 100 : value * 8) * 2)));
-            builder8.buildAndRegister();
-
-            IntCircuitRecipeBuilder builder9 = GAS_CENTRIFUGE_RECIPES.recipeBuilder().duration(500 * complexity / 100).circuitMeta(8).EUt(GAValues.V[GAValues.UV]).fluidInputs(radioactiveMaterial.getFluidHexafluoride(20000));
-            radioactiveMaterial.composition.forEach((key, value) -> builder9.fluidOutputs(key.getFluidHexafluoride((value >= 5000 ? value : value >= 1000 ? value * 180 / 100 : value * 9) * 2)));
-            builder9.buildAndRegister();
-
-            IntCircuitRecipeBuilder builder10 = GAS_CENTRIFUGE_RECIPES.recipeBuilder().duration(500 * complexity / 100).circuitMeta(9).EUt(GAValues.V[GAValues.UHV]).fluidInputs(radioactiveMaterial.getFluidHexafluoride(20000));
-            radioactiveMaterial.composition.forEach((key, value) -> builder10.fluidOutputs(key.getFluidHexafluoride((value >= 5000 ? value : value >= 1000 ? value * 190 / 100 : value * 10) * 2)));
-            builder10.buildAndRegister();
-
-            IntCircuitRecipeBuilder builder11 = GAS_CENTRIFUGE_RECIPES.recipeBuilder().duration(500 * complexity / 100).circuitMeta(10).EUt(GAValues.V[GAValues.UEV]).fluidInputs(radioactiveMaterial.getFluidHexafluoride(20000));
-            radioactiveMaterial.composition.forEach((key, value) -> builder11.fluidOutputs(key.getFluidHexafluoride((value >= 5000 ? value : value >= 1000 ? value * 200 / 100 : value * 11) * 2)));
-            builder11.buildAndRegister();
-
-            IntCircuitRecipeBuilder builder12 = GAS_CENTRIFUGE_RECIPES.recipeBuilder().duration(500 * complexity / 100).circuitMeta(11).EUt(GAValues.V[GAValues.UIV]).fluidInputs(radioactiveMaterial.getFluidHexafluoride(20000));
-            radioactiveMaterial.composition.forEach((key, value) -> builder12.fluidOutputs(key.getFluidHexafluoride((value >= 5000 ? value : value >= 1000 ? value * 210 / 100 : value * 12) * 2)));
-            builder12.buildAndRegister();
-
-            IntCircuitRecipeBuilder builder13 = GAS_CENTRIFUGE_RECIPES.recipeBuilder().duration(500 * complexity / 100).circuitMeta(12).EUt(GAValues.V[GAValues.UMV]).fluidInputs(radioactiveMaterial.getFluidHexafluoride(20000));
-            radioactiveMaterial.composition.forEach((key, value) -> builder13.fluidOutputs(key.getFluidHexafluoride((value >= 5000 ? value : value >= 1000 ? value * 220 / 100 : value * 13) * 2)));
-            builder13.buildAndRegister();
-
-            IntCircuitRecipeBuilder builder14 = GAS_CENTRIFUGE_RECIPES.recipeBuilder().duration(500 * complexity / 100).circuitMeta(13).EUt(GAValues.V[GAValues.UXV]).fluidInputs(radioactiveMaterial.getFluidHexafluoride(20000));
-            radioactiveMaterial.composition.forEach((key, value) -> builder14.fluidOutputs(key.getFluidHexafluoride((value >= 5000 ? value : value >= 1000 ? value * 230 / 100 : value * 14) * 2)));
-            builder14.buildAndRegister();
-
-
+            // [Mat + F6] + 2H2O -> [Mat + F6 + 2H2O]
             radioactiveMaterial.composition.forEach((key, value) -> {
-                CRACKING_RECIPES.recipeBuilder().duration(40 * complexity / 100).EUt(120 * complexity / 100)
-                        .fluidInputs(Steam.getFluid(1000))
-                        .fluidInputs(key.getFluidHexafluoride(6000))
-                        .fluidOutputs(key.getFluidHexafluorideSteamCracked(7000))
+                CRACKING_RECIPES.recipeBuilder().duration(40 * complexity / 100).EUt(120)
+                        .fluidInputs(Steam.getFluid(2000))
+                        .fluidInputs(key.getFluidHexafluoride(1000))
+                        .fluidOutputs(key.getFluidHexafluorideSteamCracked(1000))
                         .buildAndRegister();
-                BLAST_RECIPES.recipeBuilder().blastFurnaceTemp(600).duration(600 * complexity / 100).EUt(120 * complexity / 100)
+
+                // [Mat + F6 + 2H2O] -> [Mat + 2O] + 6F + 4H (H lost)
+                BLAST_RECIPES.recipeBuilder().blastFurnaceTemp(600).duration(600 * complexity / 100).EUt(120)
                         .notConsumable(new IntCircuitIngredient(0))
-                        .fluidInputs(key.getFluidHexafluorideSteamCracked(7000))
-                        .outputs(key.getItemStack(GAEnums.GAOrePrefix.dioxide, 1))
+                        .fluidInputs(key.getFluidHexafluorideSteamCracked(1000))
+                        .outputs(key.getItemStack(GAEnums.GAOrePrefix.dioxide, 3))
                         .fluidOutputs(Fluorine.getFluid(6000))
                         .buildAndRegister();
 
-                BLAST_RECIPES.recipeBuilder().blastFurnaceTemp(600).duration(1000 * complexity / 100).EUt(120 * complexity / 100)
-                        .inputs(key.getItemStack(GAEnums.GAOrePrefix.dioxide, 1))
+                // [Mat + 2O] -> Mat + 2O
+                BLAST_RECIPES.recipeBuilder().blastFurnaceTemp(600).duration(1000 * complexity / 100).EUt(120)
+                        .inputs(key.getItemStack(GAEnums.GAOrePrefix.dioxide, 3))
                         .outputs(OreDictUnifier.get(ingot, key.getMaterial()))
                         .fluidOutputs(Oxygen.getFluid(2000))
                         .buildAndRegister();
@@ -312,18 +264,21 @@ public class NuclearHandler {
                         .inputs(isotopeMaterial.getItemStack(GAEnums.GAOrePrefix.fuelTRISO, operand))
                         .outputs(isotopeMaterial.getItemStack(GAEnums.GAOrePrefix.depletedFuelTRISO, operand))
                         .buildAndRegister();
+
                 NUCLEAR_REACTOR_RECIPES.recipeBuilder().duration(8000).EUt(((isotopeMaterial.baseHeat + operand) * operand * 2) * 105 / 100) //8000 => 105% eff
                         .baseHeatProduction((isotopeMaterial.baseHeat + operand) * operand * 2)
                         .notConsumable(new IntCircuitIngredient(operand + 10))
                         .inputs(isotopeMaterial.getItemStack(GAEnums.GAOrePrefix.fuelOxide, operand))
                         .outputs(isotopeMaterial.getItemStack(GAEnums.GAOrePrefix.depletedFuelOxide, operand))
                         .buildAndRegister();
+
                 NUCLEAR_REACTOR_RECIPES.recipeBuilder().duration(10000).EUt(((isotopeMaterial.baseHeat + operand) * operand * 2) * 110 / 100) //10000 => 110% eff
                         .baseHeatProduction((isotopeMaterial.baseHeat + operand) * operand * 2)
                         .notConsumable(new IntCircuitIngredient(operand + 10))
                         .inputs(isotopeMaterial.getItemStack(GAEnums.GAOrePrefix.fuelNitride, operand))
                         .outputs(isotopeMaterial.getItemStack(GAEnums.GAOrePrefix.depletedFuelNitride, operand))
                         .buildAndRegister();
+
                 NUCLEAR_REACTOR_RECIPES.recipeBuilder().duration(15000).EUt(((isotopeMaterial.baseHeat + operand) * operand * 2) * 120 / 100) //15000 => 120% eff
                         .baseHeatProduction((isotopeMaterial.baseHeat + operand) * operand * 2)
                         .notConsumable(new IntCircuitIngredient(operand + 10))
@@ -344,6 +299,7 @@ public class NuclearHandler {
                                                 .outputs(isotopeMaterial.getItemStack(GAEnums.GAOrePrefix.depletedFuelTRISO, operand))
                                                 .outputs(isotopeMaterialEntry.getValue().getItemStack(GAEnums.GAOrePrefix.depletedFuel, 9))
                                                 .buildAndRegister();
+
                                         NUCLEAR_REACTOR_RECIPES.recipeBuilder().duration(16000).EUt(((isotopeMaterial.baseHeat + operand) * operand / 2) * 105 / 100)
                                                 .baseHeatProduction((isotopeMaterial.baseHeat + operand) * operand)
                                                 .notConsumable(new IntCircuitIngredient(operand))
@@ -352,6 +308,7 @@ public class NuclearHandler {
                                                 .outputs(isotopeMaterial.getItemStack(GAEnums.GAOrePrefix.depletedFuelOxide, operand))
                                                 .outputs(isotopeMaterialEntry.getValue().getItemStack(GAEnums.GAOrePrefix.depletedFuel, 9))
                                                 .buildAndRegister();
+
                                         NUCLEAR_REACTOR_RECIPES.recipeBuilder().duration(20000).EUt(((isotopeMaterial.baseHeat + operand) * operand / 2) * 110 / 100)
                                                 .baseHeatProduction((isotopeMaterial.baseHeat + operand) * operand)
                                                 .notConsumable(new IntCircuitIngredient(operand))
@@ -360,6 +317,7 @@ public class NuclearHandler {
                                                 .outputs(isotopeMaterial.getItemStack(GAEnums.GAOrePrefix.depletedFuelNitride, operand))
                                                 .outputs(isotopeMaterialEntry.getValue().getItemStack(GAEnums.GAOrePrefix.depletedFuel, 9))
                                                 .buildAndRegister();
+
                                         NUCLEAR_REACTOR_RECIPES.recipeBuilder().duration(30000).EUt(((isotopeMaterial.baseHeat + operand) * operand / 2) * 120 / 100)
                                                 .baseHeatProduction((isotopeMaterial.baseHeat + operand) * operand)
                                                 .notConsumable(new IntCircuitIngredient(operand))
@@ -416,22 +374,22 @@ public class NuclearHandler {
                             ));
         } else if (isotopeMaterial != null && !isotopeMaterial.fertile && isotopeMaterial.isotopeDecay.size() > 0) {
             isotopeMaterial.isotopeDecay.keySet().forEach(isotopeMaterialDecay -> {
-                DECAY_CHAMBERS_RECIPES.recipeBuilder().duration(6000).EUt(32)
+                DECAY_CHAMBERS_RECIPES.recipeBuilder().duration(600).EUt(30)
                         .input(GAEnums.GAOrePrefix.fuelOxide, isotopeMaterial.getMaterial())
                         .chancedOutput(OreDictUnifier.get(GAEnums.GAOrePrefix.fuelOxide, isotopeMaterialDecay.getMaterial()), 9000, 100)
                         .buildAndRegister();
 
-                DECAY_CHAMBERS_RECIPES.recipeBuilder().duration(6000).EUt(32)
+                DECAY_CHAMBERS_RECIPES.recipeBuilder().duration(600).EUt(30)
                         .input(GAEnums.GAOrePrefix.fuelNitride, isotopeMaterial.getMaterial())
                         .chancedOutput(OreDictUnifier.get(GAEnums.GAOrePrefix.fuelNitride, isotopeMaterialDecay.getMaterial()), 9000, 100)
                         .buildAndRegister();
 
-                DECAY_CHAMBERS_RECIPES.recipeBuilder().duration(6000).EUt(32)
+                DECAY_CHAMBERS_RECIPES.recipeBuilder().duration(600).EUt(30)
                         .input(GAEnums.GAOrePrefix.fuelTRISO, isotopeMaterial.getMaterial())
                         .chancedOutput(OreDictUnifier.get(GAEnums.GAOrePrefix.fuelTRISO, isotopeMaterialDecay.getMaterial()), 9000, 100)
                         .buildAndRegister();
 
-                DECAY_CHAMBERS_RECIPES.recipeBuilder().duration(6000).EUt(32)
+                DECAY_CHAMBERS_RECIPES.recipeBuilder().duration(600).EUt(30)
                         .input(GAEnums.GAOrePrefix.fuelZirconiumAlloy, isotopeMaterial.getMaterial())
                         .chancedOutput(OreDictUnifier.get(GAEnums.GAOrePrefix.fuelZirconiumAlloy, isotopeMaterialDecay.getMaterial()), 9000, 100)
                         .buildAndRegister();

--- a/src/main/java/gregicadditions/recipes/categories/handlers/NuclearHandler.java
+++ b/src/main/java/gregicadditions/recipes/categories/handlers/NuclearHandler.java
@@ -234,19 +234,19 @@ public class NuclearHandler {
             builder1.buildAndRegister();
 
             radioactiveMaterial.composition.forEach((key, value) -> {
-                // [Mat + F6] + 2H2O -> [Mat + F6 + 2H2O]
+                // [Mat + F6] + 3H2O -> [Mat + F6 + 3H2O]
                 CRACKING_RECIPES.recipeBuilder().duration(40 * complexity / 100).EUt(120)
-                        .fluidInputs(Steam.getFluid(2000))
+                        .fluidInputs(Steam.getFluid(3000))
                         .fluidInputs(key.getFluidHexafluoride(1000))
                         .fluidOutputs(key.getFluidHexafluorideSteamCracked(1000))
                         .buildAndRegister();
 
-                // [Mat + F6 + 2H2O] -> [Mat + 2O] + 6F + 4H (H lost)
+                // [Mat + F6 + 3H2O] -> [Mat + 2O] + 6HF + O (O lost)
                 BLAST_RECIPES.recipeBuilder().blastFurnaceTemp(600).duration(600 * complexity / 100).EUt(120)
                         .notConsumable(new IntCircuitIngredient(0))
                         .fluidInputs(key.getFluidHexafluorideSteamCracked(1000))
                         .outputs(key.getItemStack(GAEnums.GAOrePrefix.dioxide, 3))
-                        .fluidOutputs(Fluorine.getFluid(6000))
+                        .fluidOutputs(HydrofluoricAcid.getFluid(6000))
                         .buildAndRegister();
 
                 // [Mat + 2O] -> Mat + 2O


### PR DESCRIPTION
This PR addresses the massive loss in fluorine resulting from the Nuclear Process. 

First, this PR fixes the remaining chemistry problems within the NuclearHandler, except for one recipe which would require extra item inputs and would cause significant problems for existing setups. The Nitrite materials are also actually supposed to be Nitrates, and the chemistry reflects this. Durations and EUts have been made static for all inputs, allowing automation of the process to be more standardized. The durations have also been reduced.

The Gas Centrifuge is the cause of the fluorine loss, and could also lead to positive fluorine loops. This PR changes the gas centrifuge to only have one recipe per nuclear input fluid, which is equivalent to the old ULV-tier recipe. This recipe uses 2A of HV (960EUt) and retains the same duration logic currently used. The recipe has been changed to no longer use an integrated circuit so existing setups will automatically start using the new recipe. No changes to the multiblock structure are required.

The fluorine input and output is now mathematically identical, and one can expect to recover ~118/120B with ease. The other two buckets will take longer, as they are output in smaller amounts and need 1000mB input to be recovered. 

As a result of the old ULV-tier recipe becoming the sole one, some machines are much harder to create (such as the MV decay chamber) due to the reduced isotope output for the less common variants. The most affected recipes have been altered to use the most common isotope in order to offset this. 