### PR TITLE
Fix bricks being uncraftable early game

### DIFF
--- a/src/main/java/gregicadditions/item/GAMetaItem.java
+++ b/src/main/java/gregicadditions/item/GAMetaItem.java
@@ -505,7 +505,6 @@ public class GAMetaItem extends MaterialMetaItem {
         COMPRESSED_COKE_CLAY = addItem(36, "compressed.coke.clay");
         HOT_IRON_INGOT = addItem(37, "hot_iron_ingot");
 
-        MetaItems.COMPRESSED_CLAY.setInvisible();
         MetaItems.DATA_CONTROL_CIRCUIT_IV.setInvisible();
         MetaItems.CRYSTAL_PROCESSOR_IV.setInvisible();
         MetaItems.ADVANCED_CIRCUIT_MV.setInvisible();

--- a/src/main/java/gregicadditions/recipes/categories/RecipeOverride.java
+++ b/src/main/java/gregicadditions/recipes/categories/RecipeOverride.java
@@ -427,6 +427,17 @@ public class RecipeOverride {
         removeRecipeByName("gtadditions:block_compress_clay");
         removeRecipeByName("gtadditions:block_decompress_clay");
 
+        ModHandler.addShapelessRecipe("clay_brick", COMPRESSED_CLAY.getStackForm(),
+                new ItemStack(Items.CLAY_BALL),
+                "formWood");
+
+        ModHandler.addShapedRecipe("eight_clay_brick", COMPRESSED_CLAY.getStackForm(8),
+                "BBB", "BFB", "BBB",
+                'B', new ItemStack(Items.CLAY_BALL),
+                'F', "formWood");
+
+        ModHandler.addSmeltingRecipe(COMPRESSED_CLAY.getStackForm(), new ItemStack(Items.BRICK));
+
         ALLOY_SMELTER_RECIPES.recipeBuilder().duration(200).EUt(2)
                 .inputs(new ItemStack(Items.CLAY_BALL))
                 .notConsumable(SHAPE_MOLD_INGOT)


### PR DESCRIPTION
This PR re-enables the Compressed Clay recipes and unhides it from JEI. This allows bricks to be craftable again before an Alloy Smelter.