### PR TITLE
updated digital interface to support larger amount of item/fluid/energy

### DIFF
--- a/src/main/java/gregicadditions/covers/CoverDigitalInterface.java
+++ b/src/main/java/gregicadditions/covers/CoverDigitalInterface.java
@@ -996,7 +996,7 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
         }
         int i = 1;
 
-        while (number / 10000000 != 0) {
+        while (number / 10000000 != 0 && i < units.length) {
             number = number / 1000;
             ++i;
         }

--- a/src/main/java/gregicadditions/covers/CoverDigitalInterface.java
+++ b/src/main/java/gregicadditions/covers/CoverDigitalInterface.java
@@ -110,6 +110,7 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
         MACHINE,
         PROXY;
         public static MODE[] VALUES;
+
         static {
             VALUES = MODE.values();
         }
@@ -178,15 +179,15 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
         }
     }
 
-    public void setMode(EnumFacing spin){
+    public void setMode(EnumFacing spin) {
         this.setMode(this.mode, this.slot, spin);
     }
 
-    public void setMode(int slot){
+    public void setMode(int slot) {
         this.setMode(this.mode, slot, this.spin);
     }
 
-    public void setMode(MODE mode){
+    public void setMode(MODE mode) {
         this.setMode(mode, this.slot, this.spin);
     }
 
@@ -211,7 +212,7 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
 
     public boolean unSubProxyMode(MODE mode) {
         if (this.mode == MODE.PROXY) {
-            if (proxyMode[mode.ordinal()] > 0){
+            if (proxyMode[mode.ordinal()] > 0) {
                 proxyMode[mode.ordinal()]--;
                 this.markAsDirty();
                 return true;
@@ -219,7 +220,6 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
         }
         return false;
     }
-
 
 
     @Override
@@ -237,13 +237,13 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
     @Override
     public void readFromNBT(NBTTagCompound tagCompound) {
         super.readFromNBT(tagCompound);
-        this.mode = tagCompound.hasKey("cdiMode")? MODE.VALUES[tagCompound.getByte("cdiMode")] : MODE.FLUID;
-        this.spin = tagCompound.hasKey("cdiSpin")? EnumFacing.byIndex(tagCompound.getByte("cdiSpin")) : EnumFacing.NORTH;
-        this.slot = tagCompound.hasKey("cdiSlot")? tagCompound.getInteger("cdiSlot"): 0;
-        this.proxyMode[0] = tagCompound.hasKey("cdi0")? tagCompound.getInteger("cdi0"): 0;
-        this.proxyMode[1] = tagCompound.hasKey("cdi1")? tagCompound.getInteger("cdi1"): 0;
-        this.proxyMode[2] = tagCompound.hasKey("cdi2")? tagCompound.getInteger("cdi2"): 0;
-        this.proxyMode[3] = tagCompound.hasKey("cdi3")? tagCompound.getInteger("cdi3"): 0;
+        this.mode = tagCompound.hasKey("cdiMode") ? MODE.VALUES[tagCompound.getByte("cdiMode")] : MODE.FLUID;
+        this.spin = tagCompound.hasKey("cdiSpin") ? EnumFacing.byIndex(tagCompound.getByte("cdiSpin")) : EnumFacing.NORTH;
+        this.slot = tagCompound.hasKey("cdiSlot") ? tagCompound.getInteger("cdiSlot") : 0;
+        this.proxyMode[0] = tagCompound.hasKey("cdi0") ? tagCompound.getInteger("cdi0") : 0;
+        this.proxyMode[1] = tagCompound.hasKey("cdi1") ? tagCompound.getInteger("cdi1") : 0;
+        this.proxyMode[2] = tagCompound.hasKey("cdi2") ? tagCompound.getInteger("cdi2") : 0;
+        this.proxyMode[3] = tagCompound.hasKey("cdi3") ? tagCompound.getInteger("cdi3") : 0;
 
     }
 
@@ -320,7 +320,7 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
     @Override
     public EnumActionResult onScrewdriverClick(EntityPlayer playerIn, EnumHand hand, CuboidRayTraceResult hitResult) {
         if (!this.coverHolder.getWorld().isRemote) {
-            this.openUI((EntityPlayerMP)playerIn);
+            this.openUI((EntityPlayerMP) playerIn);
         }
         return EnumActionResult.SUCCESS;
     }
@@ -336,7 +336,7 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
             if (playerIn.isSneaking() && playerIn.getHeldItemMainhand().isEmpty()) {
                 if (rayTraceResult != null && rayTraceResult.typeOfHit == RayTraceResult.Type.BLOCK) {
                     double x = 0;
-                    double y =  1 - rayTraceResult.hitVec.y + rayTraceResult.getBlockPos().getY();
+                    double y = 1 - rayTraceResult.hitVec.y + rayTraceResult.getBlockPos().getY();
                     if (rayTraceResult.sideHit == EnumFacing.EAST) {
                         x = 1 - rayTraceResult.hitVec.z + rayTraceResult.getBlockPos().getZ();
                     } else if (rayTraceResult.sideHit == EnumFacing.SOUTH) {
@@ -375,9 +375,9 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
 
     public EnumActionResult modeRightClick(EntityPlayer playerIn, EnumHand hand, MODE mode, int slot) {
         IFluidHandler fluidHandler = this.getFluidCapability();
-        if (mode == MODE.FLUID &&  fluidHandler!= null) {
+        if (mode == MODE.FLUID && fluidHandler != null) {
             if (!FluidUtil.interactWithFluidHandler(playerIn, hand, fluidHandler)) {
-                if(fluidHandler instanceof FluidHandlerProxy && FluidUtil.interactWithFluidHandler(playerIn, hand, ((FluidHandlerProxy) fluidHandler).input)) {
+                if (fluidHandler instanceof FluidHandlerProxy && FluidUtil.interactWithFluidHandler(playerIn, hand, ((FluidHandlerProxy) fluidHandler).input)) {
                     return EnumActionResult.SUCCESS;
                 }
                 return EnumActionResult.PASS;
@@ -398,7 +398,7 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
                     } else {
                         ItemStack itemStack = hold.copy();
                         itemStack.setCount(1);
-                        if (itemHandler.insertItem(slot, itemStack, false).isEmpty()){
+                        if (itemHandler.insertItem(slot, itemStack, false).isEmpty()) {
                             hold.setCount(hold.getCount() - 1);
                             flag = true;
                         }
@@ -412,7 +412,7 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
                             }
                         }
                     }
-                    return flag? EnumActionResult.SUCCESS: EnumActionResult.PASS;
+                    return flag ? EnumActionResult.SUCCESS : EnumActionResult.PASS;
                 }
             }
             return EnumActionResult.PASS;
@@ -438,7 +438,7 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
                     itemStack = itemHandler.extractItem(slot, 1, false);
                 }
                 if (itemStack.isEmpty() && itemHandler instanceof ItemHandlerProxy) {
-                    IItemHandler insertHandler = ObfuscationReflectionHelper.getPrivateValue(ItemHandlerProxy.class, (ItemHandlerProxy)itemHandler, "insertHandler");
+                    IItemHandler insertHandler = ObfuscationReflectionHelper.getPrivateValue(ItemHandlerProxy.class, (ItemHandlerProxy) itemHandler, "insertHandler");
                     if (slot < insertHandler.getSlots()) {
                         if (entityPlayer.isSneaking()) {
                             itemStack = insertHandler.extractItem(slot, 64, false);
@@ -465,19 +465,24 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
         ToggleButtonWidget[] buttons = new ToggleButtonWidget[5];
         buttons[0] = new ToggleButtonWidget(40, 20, 20, 20, ClientHandler.BUTTON_FLUID, () -> this.mode == MODE.FLUID, (pressed) -> {
             if (pressed) setMode(MODE.FLUID);
-        }).setTooltipText("metaitem.cover.digital.mode.fluid");;
+        }).setTooltipText("metaitem.cover.digital.mode.fluid");
+        ;
         buttons[1] = new ToggleButtonWidget(60, 20, 20, 20, ClientHandler.BUTTON_ITEM, () -> this.mode == MODE.ITEM, (pressed) -> {
             if (pressed) setMode(MODE.ITEM);
-        }).setTooltipText("metaitem.cover.digital.mode.item");;
+        }).setTooltipText("metaitem.cover.digital.mode.item");
+        ;
         buttons[2] = new ToggleButtonWidget(80, 20, 20, 20, ClientHandler.BUTTON_ENERGY, () -> this.mode == MODE.ENERGY, (pressed) -> {
             if (pressed) setMode(MODE.ENERGY);
-        }).setTooltipText("metaitem.cover.digital.mode.energy");;
+        }).setTooltipText("metaitem.cover.digital.mode.energy");
+        ;
         buttons[3] = new ToggleButtonWidget(100, 20, 20, 20, ClientHandler.BUTTON_MACHINE, () -> this.mode == MODE.MACHINE, (pressed) -> {
             if (pressed) setMode(MODE.MACHINE);
-        }).setTooltipText("metaitem.cover.digital.mode.machine");;
+        }).setTooltipText("metaitem.cover.digital.mode.machine");
+        ;
         buttons[4] = new ToggleButtonWidget(140, 20, 20, 20, ClientHandler.BUTTON_INTERFACE, () -> this.mode == MODE.PROXY, (pressed) -> {
             if (pressed) setMode(MODE.PROXY);
-        }).setTooltipText("metaitem.cover.digital.mode.proxy");;
+        }).setTooltipText("metaitem.cover.digital.mode.proxy");
+        ;
         primaryGroup.addWidget(new LabelWidget(10, 25, "metaitem.cover.digital.title.mode", 0));
         primaryGroup.addWidget(buttons[0]);
         primaryGroup.addWidget(buttons[1]);
@@ -486,8 +491,8 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
         primaryGroup.addWidget(buttons[4]);
 
         primaryGroup.addWidget(new LabelWidget(10, 50, "monitor.gui.title.slot", 0));
-        primaryGroup.addWidget(new ClickButtonWidget(40, 45, 20, 20, "-1", (data) -> setMode(slot - (data.isShiftClick? 10 : 1))));
-        primaryGroup.addWidget(new ClickButtonWidget(140, 45, 20, 20, "+1", (data) -> setMode(slot + (data.isShiftClick? 10 : 1))));
+        primaryGroup.addWidget(new ClickButtonWidget(40, 45, 20, 20, "-1", (data) -> setMode(slot - (data.isShiftClick ? 10 : 1))));
+        primaryGroup.addWidget(new ClickButtonWidget(140, 45, 20, 20, "+1", (data) -> setMode(slot + (data.isShiftClick ? 10 : 1))));
         primaryGroup.addWidget(new ImageWidget(60, 45, 80, 20, GuiTextures.DISPLAY));
         primaryGroup.addWidget(new SimpleTextWidget(100, 55, "", 16777215, () -> Integer.toString(this.slot)));
 
@@ -517,7 +522,7 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
                             fluidTankProperties[i].canFill() != fluids[i].canFill()) {
                         syncFlag = true;
                         fluids[i] = new FluidTankProperties(content, fluidTankProperties[i].getCapacity(), fluidTankProperties[i].canFill(), fluidTankProperties[i].canDrain());
-                    } else if(content != null && (content.amount != fluids[i].getContents().amount || !content.isFluidEqual(fluids[i].getContents()))) {
+                    } else if (content != null && (content.amount != fluids[i].getContents().amount || !content.isFluidEqual(fluids[i].getContents()))) {
                         syncFlag = true;
                         fluids[i] = new FluidTankProperties(content, fluidTankProperties[i].getCapacity(), fluidTankProperties[i].canFill(), fluidTankProperties[i].canDrain());
                     }
@@ -525,11 +530,11 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
             }
             if (syncFlag) writeUpdateData(2, this::writeFluids);
         }
-        if(mode == MODE.ITEM || (mode == MODE.PROXY && proxyMode[1] > 0)) {
+        if (mode == MODE.ITEM || (mode == MODE.PROXY && proxyMode[1] > 0)) {
             boolean syncFlag = false;
             IItemHandler itemHandler = this.getItemCapability();
             if (this.coverHolder instanceof MetaTileEntityQuantumChest) {
-                long maxStoredItems = ObfuscationReflectionHelper.getPrivateValue(MetaTileEntityQuantumChest.class, (MetaTileEntityQuantumChest)this.coverHolder, "maxStoredItems");
+                long maxStoredItems = ObfuscationReflectionHelper.getPrivateValue(MetaTileEntityQuantumChest.class, (MetaTileEntityQuantumChest) this.coverHolder, "maxStoredItems");
                 if (maxStoredItems != quantumChestCapability) {
                     quantumChestCapability = (int) maxStoredItems;
                     syncFlag = true;
@@ -540,7 +545,7 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
                     syncFlag = true;
                 }
             }
-            if(itemHandler != null) {
+            if (itemHandler != null) {
                 int size = itemHandler.getSlots();
                 if (items.length != size) {
                     items = new ItemStack[size];
@@ -666,7 +671,7 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
                     items[i] = new ItemStack(nbt);
                     items[i].setCount(nbt.getInteger("count"));
                 } else {
-                    items [i] = ItemStack.EMPTY;
+                    items[i] = ItemStack.EMPTY;
                 }
             }
         } catch (IOException e) {
@@ -797,19 +802,19 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
         Rotation rotation = new Rotation(0, 0, 1, 0);
         if (this.attachedSide == EnumFacing.UP || this.attachedSide == EnumFacing.DOWN) {
             if (this.spin == EnumFacing.WEST) {
-                translation.translate(0 , 0, 1);
-                rotation = new Rotation(Math.PI/2, 0, 1, 0);
+                translation.translate(0, 0, 1);
+                rotation = new Rotation(Math.PI / 2, 0, 1, 0);
             } else if (this.spin == EnumFacing.EAST) {
-                translation.translate(1 , 0, 0);
-                rotation = new Rotation(-Math.PI/2, 0, 1, 0);
+                translation.translate(1, 0, 0);
+                rotation = new Rotation(-Math.PI / 2, 0, 1, 0);
             } else if (this.spin == EnumFacing.SOUTH) {
-                translation.translate(1 , 0, 1);
+                translation.translate(1, 0, 1);
                 rotation = new Rotation(Math.PI, 0, 1, 0);
             }
             translation.apply(rotation);
         }
         if (mode == MODE.PROXY) {
-          ClientHandler.COVER_INTERFACE_PROXY.renderSided(this.attachedSide, cuboid6, ccRenderState, ArrayUtils.addAll(ops, rotation), RenderHelper.adjustTrans(translation, this.attachedSide, 1));
+            ClientHandler.COVER_INTERFACE_PROXY.renderSided(this.attachedSide, cuboid6, ccRenderState, ArrayUtils.addAll(ops, rotation), RenderHelper.adjustTrans(translation, this.attachedSide, 1));
         } else if (mode == MODE.FLUID) {
             ClientHandler.COVER_INTERFACE_FLUID.renderSided(this.attachedSide, cuboid6, ccRenderState, ArrayUtils.addAll(ops, rotation), RenderHelper.adjustTrans(translation, this.attachedSide, 1));
             ClientHandler.COVER_INTERFACE_FLUID_GLASS.renderSided(this.attachedSide, cuboid6, ccRenderState, ArrayUtils.addAll(ops, rotation), RenderHelper.adjustTrans(translation, this.attachedSide, 3));
@@ -869,14 +874,14 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
             if (rayTraceResult != null && rayTraceResult.typeOfHit == RayTraceResult.Type.BLOCK && rayTraceResult.sideHit == side && rayTraceResult.getBlockPos().equals(blockPos)) {
                 RenderHelper.renderRect(-7f / 16, -7f / 16, 3f / 16, 3f / 16, 0.002f, 0XFF838583);
                 RenderHelper.renderRect(4f / 16, -7f / 16, 3f / 16, 3f / 16, 0.002f, 0XFF838583);
-                RenderHelper.renderText(-5.5f / 16, -5.5F/16, 0, 1.0f / 70, 0XFFFFFFFF, "<", true);
-                RenderHelper.renderText(5.7f / 16, -5.5F/16, 0, 1.0f / 70, 0XFFFFFFFF, ">", true);
-                RenderHelper.renderText(0, -5.5F/16, 0, 1.0f / 120, 0XFFFFFFFF, "Slot: " + slot, true);
-                if (this.coverHolder instanceof MetaTileEntity){
+                RenderHelper.renderText(-5.5f / 16, -5.5F / 16, 0, 1.0f / 70, 0XFFFFFFFF, "<", true);
+                RenderHelper.renderText(5.7f / 16, -5.5F / 16, 0, 1.0f / 70, 0XFFFFFFFF, ">", true);
+                RenderHelper.renderText(0, -5.5F / 16, 0, 1.0f / 120, 0XFFFFFFFF, "Slot: " + slot, true);
+                if (this.coverHolder instanceof MetaTileEntity) {
                     RenderHelper.renderRect(-7f / 16, -4f / 16, 14f / 16, 1f / 16, 0.002f, 0XFF000000);
-                    RenderHelper.renderText(0, -3.5F/16, 0, 1.0f / 200, 0XFFFFFFFF, I18n.format(((MetaTileEntity) this.coverHolder).getMetaFullName()), true);
+                    RenderHelper.renderText(0, -3.5F / 16, 0, 1.0f / 200, 0XFFFFFFFF, I18n.format(((MetaTileEntity) this.coverHolder).getMetaFullName()), true);
                 }
-                RenderHelper.renderItemOverLay(-8f/16, -5f/16, 0.002f, 1f/32, this.coverHolder.getStackForm());
+                RenderHelper.renderItemOverLay(-8f / 16, -5f / 16, 0.002f, 1f / 32, this.coverHolder.getStackForm());
                 return true;
             }
         }
@@ -898,7 +903,7 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
 
     @SideOnly(Side.CLIENT)
     private void renderMachineMode(float partialTicks) {
-        int color = energyCapability > 10 * energyStored ? 0XFFFF2F39 : isWorkingEnable? 0XFF00FF00 : 0XFFFF662E;
+        int color = energyCapability > 10 * energyStored ? 0XFFFF2F39 : isWorkingEnable ? 0XFF00FF00 : 0XFFFF662E;
         if (isActive && maxProgress != 0) {
             float offset = ((this.coverHolder.getTimer() % 20 + partialTicks) * 0.875f / 20);
             float start = Math.max(-0.4375f, -0.875f + 2 * offset);
@@ -907,20 +912,20 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
             int endAlpha = 0XFF;
             if (offset < 0.4375f) {
                 startAlpha = (int) (255 - 255 / 0.4375 * offset);
-            } else if(start > 0.4375) {
+            } else if (start > 0.4375) {
                 endAlpha = (int) (510 - 255 / 0.4375 * offset);
             }
             RenderHelper.renderRect(-7f / 16, -7f / 16, progress * 14f / (maxProgress * 16), 3f / 16, 0.002f, 0XFFFF5F44);
-            RenderHelper.renderText(0, -5.5F/16, 0, 1.0f / (isProxy()? 110 : 70), 0XFFFFFFFF, readAmountOrCountOrEnergy(progress * 100 / maxProgress, MODE.MACHINE), true);
+            RenderHelper.renderText(0, -5.5F / 16, 0, 1.0f / (isProxy() ? 110 : 70), 0XFFFFFFFF, readAmountOrCountOrEnergy(progress * 100 / maxProgress, MODE.MACHINE), true);
             RenderHelper.renderGradientRect(start, -4f / 16, width, 1f / 16, 0.002f, (color & 0X00FFFFFF) | (startAlpha << 24), (color & 0X00FFFFFF) | (endAlpha << 24), true);
         } else {
             RenderHelper.renderRect(-7f / 16, -4f / 16, 14f / 16, 1f / 16, 0.002f, color);
         }
         if (this.isProxy()) {
             if (isWorkingEnable) {
-                RenderHelper.renderTextureArea(ClientHandler.COVER_INTERFACE_MACHINE_ON_PROXY,-7f / 16, 1f / 16, 14f / 16, 3f / 16, 0.002f);
+                RenderHelper.renderTextureArea(ClientHandler.COVER_INTERFACE_MACHINE_ON_PROXY, -7f / 16, 1f / 16, 14f / 16, 3f / 16, 0.002f);
             } else {
-                RenderHelper.renderTextureArea(ClientHandler.COVER_INTERFACE_MACHINE_OFF_PROXY,-7f / 16, -1f / 16, 14f / 16, 5f / 16, 0.002f);
+                RenderHelper.renderTextureArea(ClientHandler.COVER_INTERFACE_MACHINE_OFF_PROXY, -7f / 16, -1f / 16, 14f / 16, 5f / 16, 0.002f);
             }
         }
     }
@@ -935,25 +940,25 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
         for (long d : outputEnergyList) {
             max = Math.max(max, d);
         }
-        RenderHelper.renderLineChart(inputEnergyList, max,-5.5f/16, 5.5f/16, 12f/16,6f/16,0.005f,0XFF03FF00);
-        RenderHelper.renderLineChart(outputEnergyList, max,-5.5f/16, 5.5f/16, 12f/16,6f/16,0.005f,0XFFFF2F39);
-        RenderHelper.renderText(-5.7f/16, -2.3f/16, 0, 1.0f / 270, 0XFF03FF00, "EU I: " + energyInputPerDur + "EU/s", false);
-        RenderHelper.renderText(-5.7f/16, -1.6f/16, 0, 1.0f / 270, 0XFFFF0000, "EU O: " + energyOutputPerDur + "EU/s", false);
+        RenderHelper.renderLineChart(inputEnergyList, max, -5.5f / 16, 5.5f / 16, 12f / 16, 6f / 16, 0.005f, 0XFF03FF00);
+        RenderHelper.renderLineChart(outputEnergyList, max, -5.5f / 16, 5.5f / 16, 12f / 16, 6f / 16, 0.005f, 0XFFFF2F39);
+        RenderHelper.renderText(-5.7f / 16, -2.3f / 16, 0, 1.0f / 270, 0XFF03FF00, "EU I: " + energyInputPerDur + "EU/s", false);
+        RenderHelper.renderText(-5.7f / 16, -1.6f / 16, 0, 1.0f / 270, 0XFFFF0000, "EU O: " + energyOutputPerDur + "EU/s", false);
         RenderHelper.renderRect(-7f / 16, -7f / 16, energyStored * 14f / (energyCapability * 16), 3f / 16, 0.002f, 0XFFFFD817);
-        RenderHelper.renderText(0, -5.5F/16, 0, 1.0f / (isProxy()? 110 : 70), 0XFFFFFFFF, readAmountOrCountOrEnergy(energyStored, MODE.ENERGY), true);
+        RenderHelper.renderText(0, -5.5F / 16, 0, 1.0f / (isProxy() ? 110 : 70), 0XFFFFFFFF, readAmountOrCountOrEnergy(energyStored, MODE.ENERGY), true);
     }
 
     @SideOnly(Side.CLIENT)
     private void renderItemMode(int slot) {
         ItemStack itemStack = items[slot];
         if (!itemStack.isEmpty()) {
-           RenderHelper.renderItemOverLay(-8f/16, -5f/16, 0, 1f/32, itemStack);
-           if(quantumChestCapability != 0) {
-               RenderHelper.renderRect(-7f / 16, -7f / 16, Math.max(itemStack.getCount() * 14f / (quantumChestCapability * 16), 0.001f), 3f / 16, 0.002f, 0XFF25B9FF);
-           } else {
-               RenderHelper.renderRect(-7f / 16, -7f / 16, Math.max(itemStack.getCount() * 14f / (itemStack.getMaxStackSize() * 16), 0.001f), 3f / 16, 0.002f, 0XFF25B9FF);
-           }
-           RenderHelper.renderText(0, -5.5F/16, 0, 1.0f / (isProxy()? 110 : 70), 0XFFFFFFFF, readAmountOrCountOrEnergy(itemStack.getCount(), MODE.ITEM), true);
+            RenderHelper.renderItemOverLay(-8f / 16, -5f / 16, 0, 1f / 32, itemStack);
+            if (quantumChestCapability != 0) {
+                RenderHelper.renderRect(-7f / 16, -7f / 16, Math.max(itemStack.getCount() * 14f / (quantumChestCapability * 16), 0.001f), 3f / 16, 0.002f, 0XFF25B9FF);
+            } else {
+                RenderHelper.renderRect(-7f / 16, -7f / 16, Math.max(itemStack.getCount() * 14f / (itemStack.getMaxStackSize() * 16), 0.001f), 3f / 16, 0.002f, 0XFF25B9FF);
+            }
+            RenderHelper.renderText(0, -5.5F / 16, 0, 1.0f / (isProxy() ? 110 : 70), 0XFFFFFFFF, readAmountOrCountOrEnergy(itemStack.getCount(), MODE.ITEM), true);
 
         }
     }
@@ -962,30 +967,40 @@ public class CoverDigitalInterface extends CoverBehavior implements IRenderMetaT
     private void renderFluidMode(int slot) {
         FluidStack fluidStack = fluids[slot].getContents();
         assert fluidStack != null;
-        float height =  10f / 16 * Math.max(fluidStack.amount * 1.0f / fluids[slot].getCapacity(), 0.001f);
+        float height = 10f / 16 * Math.max(fluidStack.amount * 1.0f / fluids[slot].getCapacity(), 0.001f);
         RenderHelper.renderFluidOverLay(-7f / 16, 0.4375f - height, 14f / 16, height, 0.002f, fluidStack, 0.8f);
         int fluidColor = WidgetOreList.getFluidColor(fluidStack.getFluid());
         int textColor = ((fluidColor & 0xff) + ((fluidColor >> 8) & 0xff) + ((fluidColor >> 16) & 0xff)) / 3 > (255 / 2) ? 0X0 : 0XFFFFFFFF;
         RenderHelper.renderRect(-7f / 16, -7f / 16, 14f / 16, 3f / 16, 0.002f, fluidColor | (255 << 24));
-        RenderHelper.renderText(0, -5.5F/16, 0, 1.0f / (isProxy()? 110 : 70), textColor, readAmountOrCountOrEnergy(fluidStack.amount, MODE.FLUID), true);
+        RenderHelper.renderText(0, -5.5F / 16, 0, 1.0f / (isProxy() ? 110 : 70), textColor, readAmountOrCountOrEnergy(fluidStack.amount, MODE.FLUID), true);
     }
 
     static String[][] units = {
             {"", "mB", "", "EU"},
             {"", "B", "K", "KEU"},
             {"", "KB", "M", "MEU"},
+            {"", "MB", "G", "GEU"},
+            {"", "GB", "T", "TEU"},
+            {"", "TB", "P", "PEU"},
     };
+
     @SideOnly(Side.CLIENT)
     private String readAmountOrCountOrEnergy(long number, MODE mode) {
         int unit = mode == MODE.FLUID ? 1 : mode == MODE.ITEM ? 2 : mode == MODE.ENERGY ? 3 : 0;
         if (mode == MODE.MACHINE) {
             return number + "%";
         }
+
         if (number / 1000 == 0) {
             return number + units[0][unit];
-        } else if (number / 1000000 == 0) {
-            return new DecimalFormat("#.#").format(number * 1.0f / 1000) + units[1][unit];
         }
-        return new DecimalFormat("#.#").format(number * 1.0f / 1000000) + units[2][unit];
+        int i = 1;
+
+        while (number / 10000000 != 0) {
+            number = number / 1000;
+            ++i;
+        }
+
+        return new DecimalFormat("#.#").format(number * 1.0f / 1000) + units[i][unit];
     }
 }


### PR DESCRIPTION
One of my friend pointed out that when using the mulktiblock battery the number showed by the digital interface may  overflow from where it should be:

![](https://cdn.discordapp.com/attachments/763408591126265867/850431315617644544/2021-06-04_14.03.38.png)

i fixed this by changing a little the computation in order to make easier to add new  unit tier (yeah not sure about how to says this) and adding the Giga Terra and Peta prefix hopping it should be enough

![](https://cdn.discordapp.com/attachments/763408591126265867/850432570382221342/2021-06-04_19.40.25.png)