### PR TITLE
More Recipe Fixes

### DIFF
--- a/src/main/java/gregicadditions/GAConfig.java
+++ b/src/main/java/gregicadditions/GAConfig.java
@@ -59,6 +59,9 @@ public class GAConfig {
         @Config.Comment("Change the recipe of rods to result in 1 stick and 2 small piles of dusts.")
         public boolean stickGT5U = false;
 
+        @Config.Comment("Change the manual recipe of Small Gears to be more expensive")
+        public boolean smallGearGT5U = true;
+
         @Config.Comment("Various 2x2 and 3x3 Compression and Uncompression Recipes")
         @Config.Name("Compression - Generate Compressor Recipes for blocks")
         public boolean GenerateCompressorRecipes = true;

--- a/src/main/java/gregicadditions/GAConfig.java
+++ b/src/main/java/gregicadditions/GAConfig.java
@@ -59,15 +59,21 @@ public class GAConfig {
         @Config.Comment("Change the recipe of rods to result in 1 stick and 2 small piles of dusts.")
         public boolean stickGT5U = false;
 
-        @Config.Comment("Various 2x2 and 3x3 Compression and Uncompression Recipes")
-        @Config.Name("Compression - Generate Compressor Recipes for blocks")
-        public boolean GenerateCompressorRecipes = true;
-        @Config.Name("Compression - Move 3x3 Crafting Recipes for blocks to the Packager (except tiny dusts)")
-        public boolean Remove3x3BlockRecipes = true;
-        @Config.Name("Compression - Move 1 to 9 Crafting Recipes to the Unpackager (except tiny dusts)")
-        public boolean RemoveBlockUncraftingRecipes = true;
-        @Config.Name("Compression - Add 2x2 Crafting Recipes to the Packager")
-        public boolean Packager2x2Recipes = true;
+        @Config.Comment("3x3 Crafting Table Recipe Removals")
+        @Config.Name("Crafting - Remove 3x3 Block Crafting Recipes from Crafting Table")
+        public boolean Remove3x3BlockRecipes = false;
+        @Config.Name("Crafting - Remove 3x3 Nugget Crafting Recipes from Crafting Table")
+        public boolean Remove3x3NuggetRecipes = false;
+        @Config.Name("Crafting - Remove 3x3 Misc Recipes from Crafting Table (all others)")
+        public boolean Remove3x3MiscRecipes = false;
+
+        @Config.Comment("1->9 Crafting Table Recipe Removals")
+        @Config.Name("Crafting - Remove 1->9 Block Uncrafting Recipes from Crafting Table")
+        public boolean Remove1to9BlockRecipes = false;
+        @Config.Name("Crafting - Remove 1->9 Nugget Uncrafting Recipes from Crafting Table")
+        public boolean Remove1to9NuggetRecipes = false;
+        @Config.Name("Crafting - Remove 1-> Misc Recipes from Crafting Table (all others)")
+        public boolean Remove1to9MiscRecipes = false;
 
         @Config.Comment("Set to false to enable Log>Charcoal smelting recipes")
         @Config.Name("All Log to Charcoal smelting recipes will be removed")

--- a/src/main/java/gregicadditions/GAConfig.java
+++ b/src/main/java/gregicadditions/GAConfig.java
@@ -59,9 +59,6 @@ public class GAConfig {
         @Config.Comment("Change the recipe of rods to result in 1 stick and 2 small piles of dusts.")
         public boolean stickGT5U = false;
 
-        @Config.Comment("Change the manual recipe of Small Gears to be more expensive")
-        public boolean smallGearGT5U = true;
-
         @Config.Comment("Various 2x2 and 3x3 Compression and Uncompression Recipes")
         @Config.Name("Compression - Generate Compressor Recipes for blocks")
         public boolean GenerateCompressorRecipes = true;

--- a/src/main/java/gregicadditions/GAMaterials.java
+++ b/src/main/java/gregicadditions/GAMaterials.java
@@ -1585,6 +1585,8 @@ public class GAMaterials implements IMaterialHandler {
         OrePrefix.dustTiny.setIgnored(Snow);
 
         Magnetite.setDirectSmelting(Iron);
+        BasalticMineralSand.setDirectSmelting(Iron);
+        GraniticMineralSand.setDirectSmelting(Iron);
 
         Duranium.addFlag(GENERATE_FOIL);
         Graphene.addFlag(GENERATE_FOIL);

--- a/src/main/java/gregicadditions/GAMaterials.java
+++ b/src/main/java/gregicadditions/GAMaterials.java
@@ -756,7 +756,7 @@ public class GAMaterials implements IMaterialHandler {
     public static final SimpleFluidMaterial RedMud = new SimpleFluidMaterial("red_mud", 0xcc3300, "HCl?");
     public static final SimpleFluidMaterial NeutralisedRedMud = new SimpleFluidMaterial("neutralised_red_mud", 0xcc3300, "Fe??");
     public static final SimpleFluidMaterial FerricREEChloride = new SimpleFluidMaterial("ferric_ree_chloride", 0x30301a, "Fe?");
-    public static final SimpleFluidMaterial RedSlurry = new SimpleFluidMaterial("red_slurry", 0xcc3300, "TiSiO2?");
+    public static final SimpleFluidMaterial RedSlurry = new SimpleFluidMaterial("red_slurry", 0xcc3300, "TiO2?");
     public static final SimpleFluidMaterial TitaniumDisulfate = new SimpleFluidMaterial("titanium_disulfate", 0xdc3d7c, "TiO(SO4)");
     public static final SimpleFluidMaterial RubySlurry = new SimpleFluidMaterial("ruby_slurry", Ruby.materialRGB, "?");
     public static final SimpleFluidMaterial SapphireSlurry = new SimpleFluidMaterial("sapphire_slurry", Sapphire.materialRGB, "?");

--- a/src/main/java/gregicadditions/item/GAMetaItem.java
+++ b/src/main/java/gregicadditions/item/GAMetaItem.java
@@ -23,6 +23,7 @@ import net.minecraftforge.fml.common.Loader;
 
 import static gregicadditions.GAMaterials.*;
 import static gregicadditions.item.GAMetaItems.*;
+import static gregtech.api.GTValues.M;
 import static gregtech.api.unification.material.Materials.Americium;
 import static gregtech.api.unification.material.Materials.Thorium;
 
@@ -80,10 +81,10 @@ public class GAMetaItem extends MaterialMetaItem {
         PLUGIN_TEXT = addItem(129, "plugin.text").addComponents(new TextPluginBehavior());
         COVER_DIGITAL_INTERFACE = addItem(130, "cover.digital");
 
-        SCHEMATIC = addItem(131, "schematic").setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.StainlessSteel, 7257600L)));
-        SCHEMATIC_2X2 = addItem(132, "schematic.2by2").setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.StainlessSteel, 7257600L)));
-        SCHEMATIC_3X3 = addItem(133, "schematic.3by3").setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.StainlessSteel, 7257600L)));
-        SCHEMATIC_DUST = addItem(134, "schematic.dust").setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.StainlessSteel, 7257600L)));
+        SCHEMATIC = addItem(131, "schematic").setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 2)));
+        SCHEMATIC_2X2 = addItem(132, "schematic.2by2").setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 2)));
+        SCHEMATIC_3X3 = addItem(133, "schematic.3by3").setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 2)));
+        SCHEMATIC_DUST = addItem(134, "schematic.dust").setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 2)));
 
         PRIMITIVE_ASSEMBLY = addItem(200, "circuit.assembly.primitive").setUnificationData(OrePrefix.circuit, MarkerMaterials.Tier.Good);
         ELECTRONIC_ASSEMBLY = addItem(201, "circuit.assembly.electronic").setUnificationData(OrePrefix.circuit, MarkerMaterials.Tier.Good);

--- a/src/main/java/gregicadditions/recipes/RecipeHandler.java
+++ b/src/main/java/gregicadditions/recipes/RecipeHandler.java
@@ -197,6 +197,7 @@ public class RecipeHandler {
      * + Mixer Recipes for GTCE Materials we add
      * + Bending Cylinder Recipes
      * + GT6 Wrench Recipes (plates over ingots)
+     * + Ingot -> Nugget Alloy Smelter recipes
      */
     private static void processIngot(OrePrefix ingot, IngotMaterial material) {
 
@@ -228,6 +229,12 @@ public class RecipeHandler {
                         'X', new UnificationEntry(ingot, material));
             }
         }
+
+        ALLOY_SMELTER_RECIPES.recipeBuilder().EUt(8).duration((int) material.getAverageMass())
+                .input(ingot, material)
+                .notConsumable(MetaItems.SHAPE_MOLD_NUGGET.getStackForm())
+                .output(nugget, material, 9)
+                .buildAndRegister();
     }
 
     /**
@@ -427,26 +434,20 @@ public class RecipeHandler {
     /**
      * Nugget Material Handler. Generates:
      *
-     * + Schematic Packing and Unpacking Recipes instead of Integrated Circuits
+     * + Ingot -> Nugget Alloy Smelter Recipes
+     *
+     * - GTCE Packer / Unpacker recipes, to be registered elsewhere if configured.
      */
     private static void processNugget(OrePrefix nugget, IngotMaterial material) {
 
-        // Packer
+        // Packer / Unpacker removal, to be readded elsewhere depending on Config settings
         removeRecipesByInputs(PACKER_RECIPES, OreDictUnifier.get(nugget, material, 9), getIntegratedCircuit(1));
-
-        PACKER_RECIPES.recipeBuilder().duration(100).EUt(4)
-                .input(nugget, material, 9)
-                .notConsumable(SCHEMATIC_3X3.getStackForm())
-                .output(ingot, material)
-                .buildAndRegister();
-
-        // Unpacker
         removeRecipesByInputs(UNPACKER_RECIPES, OreDictUnifier.get(ingot, material, 1), getIntegratedCircuit(1));
 
-        UNPACKER_RECIPES.recipeBuilder().duration(100).EUt(4)
-                .input(ingot, material)
-                .notConsumable(SCHEMATIC_3X3.getStackForm())
-                .output(nugget, material, 9)
+        ALLOY_SMELTER_RECIPES.recipeBuilder().EUt(8).duration((int) material.getAverageMass())
+                .input(nugget, material, 9)
+                .notConsumable(MetaItems.SHAPE_MOLD_INGOT.getStackForm())
+                .output(ingot, material)
                 .buildAndRegister();
     }
 

--- a/src/main/java/gregicadditions/recipes/RecipeHandler.java
+++ b/src/main/java/gregicadditions/recipes/RecipeHandler.java
@@ -1109,6 +1109,7 @@ public class RecipeHandler {
                 .input(dust, Tin, 9)
                 .input(dust, Antimony)
                 .fluidOutputs(SolderingAlloy.getFluid(L * 10))
+                .notConsumable(new IntCircuitIngredient(10))
                 .buildAndRegister();
 
         // Red Alloy
@@ -1130,12 +1131,14 @@ public class RecipeHandler {
                 .input(dust, Tin)
                 .input(dust, Iron)
                 .fluidOutputs(TinAlloy.getFluid(L * 2))
+                .notConsumable(new IntCircuitIngredient(2))
                 .buildAndRegister();
 
         BLAST_ALLOY_RECIPES.recipeBuilder().duration(556).EUt(174)
                 .input(dust, Tin)
                 .input(dust, WroughtIron)
                 .fluidOutputs(TinAlloy.getFluid(L * 2))
+                .notConsumable(new IntCircuitIngredient(2))
                 .buildAndRegister();
 
         // Battery Alloy
@@ -1143,6 +1146,7 @@ public class RecipeHandler {
                 .input(dust, Lead, 4)
                 .input(dust, Antimony)
                 .fluidOutputs(BatteryAlloy.getFluid(L * 5))
+                .notConsumable(new IntCircuitIngredient(5))
                 .buildAndRegister();
 
         // Reactor Steel

--- a/src/main/java/gregicadditions/recipes/RecipeHandler.java
+++ b/src/main/java/gregicadditions/recipes/RecipeHandler.java
@@ -1457,10 +1457,14 @@ public class RecipeHandler {
     /**
      * 3x3 Single Input Recipe Generation. Generates:
      *
-     * + Compressor Recipes for 3x3 Crafting Recipes, if enabled
-     * + Packer Recipes for 3x3 Crafting Recipes, if enabled
+     * + Compressor Recipes for 3x3 Crafting Recipes
+     * + Packer Recipes for 3x3 Crafting Recipes
      *
-     * - Removes handcrafting 3x3 Recipes in favor of Packer, if enabled
+     * - Removes handcrafting 3x3 Recipes for:
+     *     - Blocks
+     *     - Nuggets
+     *     - All others
+     *   depending on config values.
      */
     private static void generate3x3Recipes(IRecipe recipe) {
 
@@ -1472,35 +1476,33 @@ public class RecipeHandler {
          || hasOrePrefix(input, "dustTiny"))
             return;
 
-        // Remove 3x3 Block Crafting to Packer
-        if (GAConfig.GT5U.Remove3x3BlockRecipes) {
-
+        if (GAConfig.GT5U.Remove3x3BlockRecipes && hasOrePrefix(output, "block"))
             removeRecipeByName(recipe.getRegistryName());
-            PACKER_RECIPES.recipeBuilder().duration(100).EUt(4)
-                    .inputs(CountableIngredient.from(input, 9))
-                    .notConsumable(SCHEMATIC_3X3.getStackForm())
-                    .outputs(output)
-                    .buildAndRegister();
-        }
 
-        // Add Compressor 3x3 Recipes
-        if (GAConfig.GT5U.GenerateCompressorRecipes) {
+        else if (GAConfig.GT5U.Remove3x3NuggetRecipes && hasOrePrefix(input, "nugget"))
+            removeRecipeByName(recipe.getRegistryName());
 
-            // Exclude Wheat, since it compresses to Plant Balls
-            if (ItemStack.areItemsEqual(input, new ItemStack(Items.WHEAT)))
-                return;
+        else if (GAConfig.GT5U.Remove3x3MiscRecipes && !hasOrePrefix(output, "block") && !hasOrePrefix(input, "nugget"))
+            removeRecipeByName(recipe.getRegistryName());
 
+        PACKER_RECIPES.recipeBuilder().duration(100).EUt(4)
+                .inputs(CountableIngredient.from(input, 9))
+                .notConsumable(SCHEMATIC_3X3.getStackForm())
+                .outputs(output)
+                .buildAndRegister();
+
+        // Exclude Wheat, since it compresses to Plant Balls
+        if (!ItemStack.areItemsEqual(input, new ItemStack(Items.WHEAT)))
             COMPRESSOR_RECIPES.recipeBuilder().duration(400).EUt(2)
                     .inputs(CountableIngredient.from(input, 9))
                     .outputs(output)
                     .buildAndRegister();
-        }
     }
 
     /**
      * 2x2 Single Input Recipe Generation. Generates:
      *
-     * + Packer Recipes for 2x2 Crafting Recipes, if enabled
+     * + Packer Recipes for 2x2 Crafting Recipes
      */
     private static void generate2x2Recipes(IRecipe recipe) {
 
@@ -1515,22 +1517,23 @@ public class RecipeHandler {
             return;
 
         // Add Packager 2x2 Recipes
-        if (GAConfig.GT5U.Packager2x2Recipes) {
-
-            PACKER_RECIPES.recipeBuilder().duration(100).EUt(4)
-                    .inputs(CountableIngredient.from(input, 4))
-                    .notConsumable(SCHEMATIC_2X2.getStackForm())
-                    .outputs(output)
-                    .buildAndRegister();
-        }
+        PACKER_RECIPES.recipeBuilder().duration(100).EUt(4)
+                .inputs(CountableIngredient.from(input, 4))
+                .notConsumable(SCHEMATIC_2X2.getStackForm())
+                .outputs(output)
+                .buildAndRegister();
     }
 
     /**
      * 1 to 9 Single Input Recipe Generation. Generates:
      *
-     * + Unpacker Recipes for 1 to 9 Crafting Recipes, if enabled
+     * + Unpacker Recipes for 1 to 9 Crafting Recipes
      *
-     * - Removes handcrafting 1 to 9 Recipes in favor of Unpacker, if enabled
+     * - Removes handcrafting 1 to 9 Recipes for:
+     *     - Blocks
+     *     - Nuggets
+     *     - All others
+     *   depending on config values.
      */
     private static void generate1to9Recipes(IRecipe recipe) {
 
@@ -1542,15 +1545,19 @@ public class RecipeHandler {
          || hasOrePrefix(output, "dustTiny"))
             return;
 
-        // Move Block Uncrafting to the Compressor
-        if (GAConfig.GT5U.RemoveBlockUncraftingRecipes) {
-
+        if (GAConfig.GT5U.Remove1to9BlockRecipes && hasOrePrefix(input, "block"))
             removeRecipeByName(recipe.getRegistryName());
-            UNPACKER_RECIPES.recipeBuilder().duration(100).EUt(8)
-                    .inputs(input)
-                    .notConsumable(SCHEMATIC_3X3.getStackForm())
-                    .outputs(output)
-                    .buildAndRegister();
-        }
+
+        else if (GAConfig.GT5U.Remove1to9NuggetRecipes && hasOrePrefix(output, "nugget"))
+            removeRecipeByName(recipe.getRegistryName());
+
+        else if (GAConfig.GT5U.Remove1to9MiscRecipes && !hasOrePrefix(input, "block") && !hasOrePrefix(output, "nugget"))
+            removeRecipeByName(recipe.getRegistryName());
+
+        UNPACKER_RECIPES.recipeBuilder().duration(100).EUt(8)
+                .inputs(input)
+                .notConsumable(SCHEMATIC_3X3.getStackForm())
+                .outputs(output)
+                .buildAndRegister();
     }
 }

--- a/src/main/java/gregicadditions/recipes/RecipeHandler.java
+++ b/src/main/java/gregicadditions/recipes/RecipeHandler.java
@@ -101,6 +101,8 @@ public class RecipeHandler {
         spring.addProcessingHandler(IngotMaterial.class, RecipeHandler::processSpring);
         springSmall.addProcessingHandler(IngotMaterial.class, RecipeHandler::processSpringSmall);
         gearSmall.addProcessingHandler(IngotMaterial.class, RecipeHandler::processGearSmall);
+        gear.addProcessingHandler(IngotMaterial.class, RecipeHandler::processGear);
+        ingotHot.addProcessingHandler(IngotMaterial.class, RecipeHandler::processIngotHot);
 
         pipeTiny.addProcessingHandler(IngotMaterial.class, RecipeHandler::processTinyPipe);
         pipeSmall.addProcessingHandler(IngotMaterial.class, RecipeHandler::processSmallPipe);
@@ -198,6 +200,7 @@ public class RecipeHandler {
      * + Bending Cylinder Recipes
      * + GT6 Wrench Recipes (plates over ingots)
      * + Ingot -> Nugget Alloy Smelter recipes
+     * + Block -> Ingot Alloy Smelter recipes
      */
     private static void processIngot(OrePrefix ingot, IngotMaterial material) {
 
@@ -235,6 +238,13 @@ public class RecipeHandler {
                 .notConsumable(MetaItems.SHAPE_MOLD_NUGGET.getStackForm())
                 .output(nugget, material, 9)
                 .buildAndRegister();
+
+        if (!OreDictUnifier.get(block, material).isEmpty())
+            ALLOY_SMELTER_RECIPES.recipeBuilder().EUt(8).duration((int) material.getAverageMass() * 9)
+                    .input(block, material)
+                    .notConsumable(MetaItems.SHAPE_MOLD_INGOT.getStackForm())
+                    .output(ingot, material, 9)
+                    .buildAndRegister();
     }
 
     /**
@@ -999,6 +1009,38 @@ public class RecipeHandler {
                     .input(ingot, material, 2)
                     .notConsumable(MetaItems.SHAPE_MOLD_GEAR_SMALL.getStackForm())
                     .output(gearSmall, material)
+                    .buildAndRegister();
+        }
+    }
+
+    /**
+     * Gear Material Handler. Generates:
+     *
+     * + Replace GTCE Gear recipe to use proper tool
+     */
+    private static void processGear(OrePrefix prefix, IngotMaterial material) {
+
+        removeRecipeByName(String.format("gtadditions:gear_%s", material.toString()));
+        ModHandler.addShapedRecipe(String.format("gear_%s", material.toString()), OreDictUnifier.get(gear, material),
+                "RPR", "PwP", "RPR",
+                'R', new UnificationEntry(stick, material),
+                'P', new UnificationEntry(plate, material));
+    }
+
+    /**
+     * Hot Ingot Material Handler. Generates:
+     *
+     * + Increased duration Hot Ingot Recipes, to make Cryogenic Freezer viable
+     */
+    private static void processIngotHot(OrePrefix prefix, IngotMaterial material) {
+
+        // Temperature at which a Hot Ingot is generated
+        if (material.blastFurnaceTemperature > 1750) {
+
+            removeRecipesByInputs(VACUUM_RECIPES, OreDictUnifier.get(ingotHot, material));
+            VACUUM_RECIPES.recipeBuilder().duration((int) (material.getAverageMass() * 3))
+                    .input(ingotHot, material)
+                    .output(ingot, material)
                     .buildAndRegister();
         }
     }

--- a/src/main/java/gregicadditions/recipes/RecipeHandler.java
+++ b/src/main/java/gregicadditions/recipes/RecipeHandler.java
@@ -973,7 +973,7 @@ public class RecipeHandler {
     /**
      * Small Gear Material Handler. Generates:
      *
-     * + GT5U Crafting Table Recipe, if enabled
+     * + Harder Small Gear Crafting Table Recipe
      * + Extruder Recipe for Small Gears
      * + Lossy Small Gear recipe in Alloy Smelter (similar to normal Gears)
      *
@@ -983,14 +983,11 @@ public class RecipeHandler {
 
         if (material.hasFlag(GENERATE_SMALL_GEAR)) {
 
-            if (GAConfig.GT5U.smallGearGT5U) {
-
-                removeRecipeByName(String.format("gtadditions:small_gear_%s", material.toString()));
-                ModHandler.addShapedRecipe(String.format("small_gear_%s", material.toString()), OreDictUnifier.get(gearSmall, material),
-                        " R ", "hPx", " R ",
-                        'R', new UnificationEntry(stick, material),
-                        'P', new UnificationEntry(plate, material));
-            }
+            removeRecipeByName(String.format("gtadditions:small_gear_%s", material.toString()));
+            ModHandler.addShapedRecipe(String.format("small_gear_%s", material.toString()), OreDictUnifier.get(gearSmall, material),
+                    " R ", "hPx", " R ",
+                    'R', new UnificationEntry(stick, material),
+                    'P', new UnificationEntry(plate, material));
 
             removeRecipesByInputs(FORGE_HAMMER_RECIPES, OreDictUnifier.get(plate, material, 2));
             EXTRUDER_RECIPES.recipeBuilder().duration((int) material.getAverageMass()).EUt(material.blastFurnaceTemperature >= 2800 ? 256 : 64)

--- a/src/main/java/gregicadditions/recipes/RecipeHandler.java
+++ b/src/main/java/gregicadditions/recipes/RecipeHandler.java
@@ -3,7 +3,6 @@ package gregicadditions.recipes;
 import gregicadditions.GAConfig;
 import gregicadditions.item.GAExplosive;
 import gregicadditions.item.GAMetaBlocks;
-import gregicadditions.item.GAMetaItems;
 import gregicadditions.materials.SimpleDustMaterialStack;
 import gregicadditions.recipes.categories.*;
 import gregicadditions.recipes.categories.circuits.CircuitRecipes;
@@ -504,7 +503,7 @@ public class RecipeHandler {
 
                 removeRecipesByInputs(BENDER_RECIPES, OreDictUnifier.get(plate, material), getIntegratedCircuit(0));
 
-                CLUSTER_MILL_RECIPES.recipeBuilder().EUt(24).duration((int) material.getMass())
+                CLUSTER_MILL_RECIPES.recipeBuilder().EUt(24).duration((int) material.getAverageMass())
                         .input(plate, material)
                         .output(foil, material, 4)
                         .buildAndRegister();
@@ -569,7 +568,7 @@ public class RecipeHandler {
                     'P', new UnificationEntry(plate, material));
         }
 
-        BENDER_RECIPES.recipeBuilder().EUt(30).duration(200)
+        BENDER_RECIPES.recipeBuilder().EUt(30).duration((int) material.getAverageMass())
                 .input(plate, material, 2)
                 .output(doublePlate, material)
                 .circuitMeta(2)
@@ -588,7 +587,7 @@ public class RecipeHandler {
                 .fluidOutputs(material.getFluid(L * 2))
                 .buildAndRegister();
 
-        ARC_FURNACE_RECIPES.recipeBuilder().EUt(30 * voltageMultiplier).duration(16)
+        ARC_FURNACE_RECIPES.recipeBuilder().EUt(30 * voltageMultiplier).duration(120)
                 .input(doublePlate, material)
                 .output(ingot, material.arcSmeltInto == null ? material : material.arcSmeltInto, 2)
                 .buildAndRegister();
@@ -604,12 +603,12 @@ public class RecipeHandler {
         removeRecipesByInputs(BENDER_RECIPES, OreDictUnifier.get(ingot, material, 9), getIntegratedCircuit(5));
         removeRecipesByInputs(BENDER_RECIPES, OreDictUnifier.get(plate, material, 9), getIntegratedCircuit(2));
 
-        BENDER_RECIPES.recipeBuilder().duration((int) material.getMass() * 4).EUt(96)
+        BENDER_RECIPES.recipeBuilder().duration((int) material.getAverageMass() * 4).EUt(96)
                 .input(plate, material, 9)
                 .output(densePlate, material, 1)
                 .circuitMeta(9)
                 .buildAndRegister();
-        BENDER_RECIPES.recipeBuilder().duration((int) material.getMass() * 9).EUt(96)
+        BENDER_RECIPES.recipeBuilder().duration((int) material.getAverageMass() * 9).EUt(96)
                 .input(ingot, material, 9)
                 .output(densePlate, material, 1)
                 .circuitMeta(9)
@@ -649,13 +648,13 @@ public class RecipeHandler {
                     'C', new UnificationEntry(plateCurved, material));
         }
 
-        BENDER_RECIPES.recipeBuilder().EUt(24).duration((int) material.getMass())
+        BENDER_RECIPES.recipeBuilder().EUt(24).duration((int) material.getAverageMass())
                 .input(plate, material)
                 .circuitMeta(1)
                 .output(plateCurved, material)
                 .buildAndRegister();
 
-        BENDER_RECIPES.recipeBuilder().EUt(24).duration((int) material.getMass())
+        BENDER_RECIPES.recipeBuilder().EUt(24).duration((int) material.getAverageMass())
                 .input(plateCurved, material)
                 .circuitMeta(0)
                 .output(plate, material)
@@ -956,14 +955,13 @@ public class RecipeHandler {
     private static void processSpringSmall(OrePrefix prefix, IngotMaterial material) {
 
         if (material.cableProperties != null)
-            removeRecipesByInputs(BENDER_RECIPES, OreDictUnifier.get(wireGtSingle, material)); // todo double check that this works
-
+            removeRecipesByInputs(BENDER_RECIPES, OreDictUnifier.get(wireGtSingle, material));
 
         ModHandler.addShapedRecipe(String.format("spring_small_%s", material.toString()), OreDictUnifier.get(springSmall, material),
                 " s ", "fRx",
                 'R', new UnificationEntry(stick, material));
 
-        BENDER_RECIPES.recipeBuilder().duration(100).EUt(8)
+        BENDER_RECIPES.recipeBuilder().duration((int) (material.getAverageMass() / 2)).EUt(8)
                 .input(stick, material)
                 .output(springSmall, material, 2)
                 .circuitMeta(1)

--- a/src/main/java/gregicadditions/recipes/RecipeHandler.java
+++ b/src/main/java/gregicadditions/recipes/RecipeHandler.java
@@ -973,7 +973,7 @@ public class RecipeHandler {
     /**
      * Small Gear Material Handler. Generates:
      *
-     * + Classic Crafting Table Recipe
+     * + GT5U Crafting Table Recipe, if enabled
      * + Extruder Recipe for Small Gears
      *
      * - Removes Forge Hammer Recipe for Small Gears
@@ -981,15 +981,17 @@ public class RecipeHandler {
     private static void processGearSmall(OrePrefix prefix, IngotMaterial material) {
 
         if (material.hasFlag(GENERATE_SMALL_GEAR)) {
-            removeRecipeByName(String.format("gtadditions:small_gear_%s", material.toString()));
 
-            ModHandler.addShapedRecipe(String.format("small_gear_%s", material.toString()), OreDictUnifier.get(gearSmall, material),
-                    " R ", "hPx", " R ",
-                    'R', new UnificationEntry(stick, material),
-                    'P', new UnificationEntry(plate, material));
+            if (GAConfig.GT5U.smallGearGT5U) {
+
+                removeRecipeByName(String.format("gtadditions:small_gear_%s", material.toString()));
+                ModHandler.addShapedRecipe(String.format("small_gear_%s", material.toString()), OreDictUnifier.get(gearSmall, material),
+                        " R ", "hPx", " R ",
+                        'R', new UnificationEntry(stick, material),
+                        'P', new UnificationEntry(plate, material));
+            }
 
             removeRecipesByInputs(FORGE_HAMMER_RECIPES, OreDictUnifier.get(plate, material, 2));
-
             EXTRUDER_RECIPES.recipeBuilder().duration((int) material.getAverageMass()).EUt(material.blastFurnaceTemperature >= 2800 ? 256 : 64)
                     .input(ingot, material)
                     .notConsumable(SHAPE_EXTRUDER_SMALL_GEAR.getStackForm())

--- a/src/main/java/gregicadditions/recipes/RecipeHandler.java
+++ b/src/main/java/gregicadditions/recipes/RecipeHandler.java
@@ -975,6 +975,7 @@ public class RecipeHandler {
      *
      * + GT5U Crafting Table Recipe, if enabled
      * + Extruder Recipe for Small Gears
+     * + Lossy Small Gear recipe in Alloy Smelter (similar to normal Gears)
      *
      * - Removes Forge Hammer Recipe for Small Gears
      */

--- a/src/main/java/gregicadditions/recipes/RecipeHandler.java
+++ b/src/main/java/gregicadditions/recipes/RecipeHandler.java
@@ -997,6 +997,12 @@ public class RecipeHandler {
                     .notConsumable(SHAPE_EXTRUDER_SMALL_GEAR.getStackForm())
                     .output(gearSmall, material)
                     .buildAndRegister();
+
+            ALLOY_SMELTER_RECIPES.recipeBuilder().duration((int) material.getAverageMass()).EUt(30)
+                    .input(ingot, material, 2)
+                    .notConsumable(MetaItems.SHAPE_MOLD_GEAR_SMALL.getStackForm())
+                    .output(gearSmall, material)
+                    .buildAndRegister();
         }
     }
 

--- a/src/main/java/gregicadditions/recipes/categories/RecipeOverride.java
+++ b/src/main/java/gregicadditions/recipes/categories/RecipeOverride.java
@@ -971,31 +971,32 @@ public class RecipeOverride {
                 'R', new UnificationEntry(ring, Iron));
 
         // Glowstone / Nether Quartz Block Recipes
-        if (GAConfig.GT5U.GenerateCompressorRecipes) {
+        if (GAConfig.GT5U.Remove3x3BlockRecipes) {
             removeRecipeByName("minecraft:glowstone");
             removeRecipeByName("minecraft:quartz_block");
             removeRecipeByName("gregtech:nether_quartz_block_to_nether_quartz");
-
-            FORGE_HAMMER_RECIPES.recipeBuilder().duration(100).EUt(24)
-                    .input(block, NetherQuartz)
-                    .output(gem, NetherQuartz, 4)
-                    .buildAndRegister();
-
-            MACERATOR_RECIPES.recipeBuilder().duration(100).EUt(24)
-                    .input(block, Glowstone)
-                    .output(dust, Glowstone, 4)
-                    .buildAndRegister();
-
-            COMPRESSOR_RECIPES.recipeBuilder().duration(400).EUt(2)
-                    .input(gem, NetherQuartz, 4)
-                    .outputs(new ItemStack(Blocks.QUARTZ_BLOCK))
-                    .buildAndRegister();
-
-            COMPRESSOR_RECIPES.recipeBuilder().EUt(16).duration(40)
-                    .inputs(new ItemStack(Items.GLOWSTONE_DUST, 4))
-                    .outputs(new ItemStack(Blocks.GLOWSTONE))
-                    .buildAndRegister();
         }
+
+        FORGE_HAMMER_RECIPES.recipeBuilder().duration(100).EUt(24)
+                .input(block, NetherQuartz)
+                .output(gem, NetherQuartz, 4)
+                .buildAndRegister();
+
+        MACERATOR_RECIPES.recipeBuilder().duration(100).EUt(24)
+                .input(block, Glowstone)
+                .output(dust, Glowstone, 4)
+                .buildAndRegister();
+
+        COMPRESSOR_RECIPES.recipeBuilder().duration(400).EUt(2)
+                .input(gem, NetherQuartz, 4)
+                .outputs(new ItemStack(Blocks.QUARTZ_BLOCK))
+                .buildAndRegister();
+
+        COMPRESSOR_RECIPES.recipeBuilder().EUt(16).duration(40)
+                .inputs(new ItemStack(Items.GLOWSTONE_DUST, 4))
+                .outputs(new ItemStack(Blocks.GLOWSTONE))
+                .buildAndRegister();
+
 
         // Glowstone Recipes
         MIXER_RECIPES.recipeBuilder().EUt(30).duration(100)

--- a/src/main/java/gregicadditions/recipes/categories/RecipeOverride.java
+++ b/src/main/java/gregicadditions/recipes/categories/RecipeOverride.java
@@ -5,6 +5,7 @@ import gregicadditions.GAMaterials;
 import gregtech.api.recipes.ModHandler;
 import gregtech.api.recipes.ingredients.IntCircuitIngredient;
 import gregtech.api.unification.OreDictUnifier;
+import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.stack.UnificationEntry;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -12,6 +13,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -20,7 +22,6 @@ import static gregicadditions.GAEnums.GAOrePrefix.plateDouble;
 import static gregicadditions.GAMaterials.*;
 import static gregicadditions.item.GAMetaItems.*;
 import static gregicadditions.recipes.GARecipeMaps.CLUSTER_MILL_RECIPES;
-import static gregicadditions.recipes.GARecipeMaps.LARGE_CHEMICAL_RECIPES;
 import static gregicadditions.recipes.helper.HelperMethods.*;
 import static gregtech.api.GTValues.L;
 import static gregtech.api.GTValues.W;
@@ -417,7 +418,7 @@ public class RecipeOverride {
                 .buildAndRegister();
 
         // Fix GTCE Hypochlorous Acid Recipe
-        removeRecipesByInputs(CHEMICAL_RECIPES, new FluidStack[]{Chlorine.getFluid(10000), Water.getFluid(10000), Mercury.getFluid(1000)});
+        removeRecipesByInputs(CHEMICAL_RECIPES, Chlorine.getFluid(10000), Water.getFluid(10000), Mercury.getFluid(1000));
 
         // 10Cl + 10H2O -> 10HClO + 10H
         CHEMICAL_RECIPES.recipeBuilder().duration(600).EUt(8)
@@ -429,7 +430,7 @@ public class RecipeOverride {
                 .buildAndRegister();
 
         // Fix GTCE Cumene Recipe
-        removeRecipesByInputs(CHEMICAL_RECIPES, new FluidStack[]{Propene.getFluid(8000), Benzene.getFluid(8000), PhosphoricAcid.getFluid(1000)});
+        removeRecipesByInputs(CHEMICAL_RECIPES, Propene.getFluid(8000), Benzene.getFluid(8000), PhosphoricAcid.getFluid(1000));
 
         // 8C3H6 + 8C6H6 -> 8C9H12
         CHEMICAL_RECIPES.recipeBuilder().duration(1920).EUt(30)
@@ -802,11 +803,11 @@ public class RecipeOverride {
                 .outputs(LARGE_FLUID_CELL_TUNGSTEN_STEEL.getStackForm())
                 .buildAndRegister();
 
-        // Oil Hydrodesulfurization Catalysis
-        removeRecipesByInputs(CHEMICAL_RECIPES, new FluidStack[]{Hydrogen.getFluid(2000), SulfuricGas.getFluid(16000)});
-        removeRecipesByInputs(CHEMICAL_RECIPES, new FluidStack[]{Hydrogen.getFluid(2000), SulfuricNaphtha.getFluid(12000)});
-        removeRecipesByInputs(CHEMICAL_RECIPES, new FluidStack[]{Hydrogen.getFluid(2000), SulfuricLightFuel.getFluid(12000)});
-        removeRecipesByInputs(CHEMICAL_RECIPES, new FluidStack[]{Hydrogen.getFluid(2000), SulfuricHeavyFuel.getFluid(8000)});
+        // Oil Desulfurization Catalysis
+        removeRecipesByInputs(CHEMICAL_RECIPES, Hydrogen.getFluid(2000), SulfuricGas.getFluid(16000));
+        removeRecipesByInputs(CHEMICAL_RECIPES, Hydrogen.getFluid(2000), SulfuricNaphtha.getFluid(12000));
+        removeRecipesByInputs(CHEMICAL_RECIPES, Hydrogen.getFluid(2000), SulfuricLightFuel.getFluid(12000));
+        removeRecipesByInputs(CHEMICAL_RECIPES, Hydrogen.getFluid(2000), SulfuricHeavyFuel.getFluid(8000));
 
         CHEMICAL_RECIPES.recipeBuilder().duration(160).EUt(30)
                 .notConsumable(new IntCircuitIngredient(0))
@@ -1089,5 +1090,69 @@ public class RecipeOverride {
 
         // Remove Bad Sulfuric Acid Recipe
         removeRecipesByInputs(CHEMICAL_RECIPES, new ItemStack[]{OreDictUnifier.get(dust, Sulfur)}, new FluidStack[]{Water.getFluid(4000)});
+
+        // Remove Small and Tiny Dust Mixer Recipes ====================================================================
+
+        ///////////////////////////////////////////////////
+        //                  Tiny Dusts                   //
+        ///////////////////////////////////////////////////
+
+        // Borosilicate Glass Tiny Dust Mixer
+        removeRecipesByInputs(MIXER_RECIPES, OreDictUnifier.get(dustTiny, Boron), OreDictUnifier.get(dustTiny, Glass, 7));
+        // Brass Mixer
+        removeRecipesByInputs(MIXER_RECIPES, OreDictUnifier.get(dustTiny, Copper, 3), OreDictUnifier.get(dustTiny, Zinc));
+        // Bronze Mixer
+        removeRecipesByInputs(MIXER_RECIPES, OreDictUnifier.get(dustTiny, Copper, 3), OreDictUnifier.get(dustTiny, Tin));
+        // Red Steel Mixer
+        removeRecipesByInputs(MIXER_RECIPES, OreDictUnifier.get(dustTiny, SterlingSilver), OreDictUnifier.get(dustTiny, BismuthBronze), OreDictUnifier.get(dustTiny, BlackSteel, 4), OreDictUnifier.get(dustTiny, Steel, 2));
+        // Blue Steel Mixer
+        removeRecipesByInputs(MIXER_RECIPES, OreDictUnifier.get(dustTiny, RoseGold), OreDictUnifier.get(dustTiny, Brass), OreDictUnifier.get(dustTiny, BlackSteel, 4), OreDictUnifier.get(dustTiny, Steel, 2));
+        // Ultimet Hand
+        removeRecipeByName("gregtech:dust_tiny_ultimet");
+        // Cobalt Brass Hand
+        removeRecipeByName("gregtech:dust_tiny_cobalt_brass");
+        // Stainless Steel Hand
+        removeRecipeByName("gregtech:dust_tiny_stainless_steel");
+        // Kanthal Hand
+        removeRecipeByName("gregtech:dust_tiny_kanthal");
+
+        ///////////////////////////////////////////////////
+        //                  Small Dusts                  //
+        ///////////////////////////////////////////////////
+
+        // Stainless Steel Mixer
+        removeRecipesByInputs(MIXER_RECIPES, OreDictUnifier.get(dustSmall, Iron, 4), OreDictUnifier.get(dustSmall, Invar, 3), OreDictUnifier.get(dustSmall, Manganese), OreDictUnifier.get(dustSmall, Chrome));
+        // Ultimet Mixer
+        removeRecipesByInputs(MIXER_RECIPES, OreDictUnifier.get(dustSmall, Cobalt, 5), OreDictUnifier.get(dustSmall, Chrome, 2), OreDictUnifier.get(dustSmall, Nickel), OreDictUnifier.get(dustSmall, Molybdenum));
+        // Cobalt Brass Mixer
+        removeRecipesByInputs(MIXER_RECIPES, OreDictUnifier.get(dustSmall, Brass, 7), OreDictUnifier.get(dustSmall, Aluminium), OreDictUnifier.get(dustSmall, Cobalt));
+        // Gunpowder from Coal Mixer
+        removeRecipesByInputs(MIXER_RECIPES, OreDictUnifier.get(dustSmall, Saltpeter, 2), OreDictUnifier.get(dustSmall, Sulfur), OreDictUnifier.get(dustSmall, Coal));
+
+        // Some of them have both Small and Tiny Dust Mixer Recipes
+        for (OrePrefix prefix : Arrays.asList(dustSmall, dustTiny)) {
+            // Indium Gallium Phosphide
+            removeRecipesByInputs(MIXER_RECIPES, OreDictUnifier.get(prefix, Indium), OreDictUnifier.get(prefix, Gallium), OreDictUnifier.get(prefix, Phosphorus));
+            // Electrum
+            removeRecipesByInputs(MIXER_RECIPES, OreDictUnifier.get(prefix, Gold), OreDictUnifier.get(prefix, Silver));
+            // Invar
+            removeRecipesByInputs(MIXER_RECIPES, OreDictUnifier.get(prefix, Iron, 2), OreDictUnifier.get(prefix, Nickel), IntCircuitIngredient.getIntegratedCircuit(1));
+            // Kanthal
+            removeRecipesByInputs(MIXER_RECIPES, OreDictUnifier.get(prefix, Iron), OreDictUnifier.get(prefix, Aluminium), OreDictUnifier.get(prefix, Chrome));
+            // Cupronickel
+            removeRecipesByInputs(MIXER_RECIPES, OreDictUnifier.get(prefix, Copper), OreDictUnifier.get(prefix, Nickel));
+            // Rose Gold
+            removeRecipesByInputs(MIXER_RECIPES, OreDictUnifier.get(prefix, Copper), OreDictUnifier.get(prefix, Gold));
+            // Sterling Silver
+            removeRecipesByInputs(MIXER_RECIPES, OreDictUnifier.get(prefix, Copper), OreDictUnifier.get(prefix, Silver, 4));
+            // Black Bronze
+            removeRecipesByInputs(MIXER_RECIPES, OreDictUnifier.get(prefix, Copper, 3), OreDictUnifier.get(prefix, Electrum, 2));
+            // Bismuth Bronze
+            removeRecipesByInputs(MIXER_RECIPES, OreDictUnifier.get(prefix, Bismuth), OreDictUnifier.get(prefix, Brass, 4));
+            // Black Steel
+            removeRecipesByInputs(MIXER_RECIPES, OreDictUnifier.get(prefix, BlackBronze), OreDictUnifier.get(prefix, Nickel), OreDictUnifier.get(prefix, Steel, 3));
+            // Gunpowder from Charcoal
+            removeRecipesByInputs(MIXER_RECIPES, OreDictUnifier.get(prefix, Saltpeter, 2), OreDictUnifier.get(prefix, Sulfur), OreDictUnifier.get(prefix, Charcoal));
+        }
     }
 }

--- a/src/main/java/gregicadditions/recipes/categories/RecipeOverride.java
+++ b/src/main/java/gregicadditions/recipes/categories/RecipeOverride.java
@@ -1038,6 +1038,13 @@ public class RecipeOverride {
                 }
             }
         }
+
+        // Steel Fluid Extraction (to allow automation of Small Steel Gears at LV)
+        removeRecipesByInputs(FLUID_EXTRACTION_RECIPES, OreDictUnifier.get(ingot, Steel));
+        FLUID_EXTRACTION_RECIPES.recipeBuilder().EUt(30).duration(80)
+                .input(ingot, Steel)
+                .fluidOutputs(Steel.getFluid(L))
+                .buildAndRegister();
     }
 
     private static void recipeRemoval() {

--- a/src/main/java/gregicadditions/recipes/categories/RecipeOverride.java
+++ b/src/main/java/gregicadditions/recipes/categories/RecipeOverride.java
@@ -1038,13 +1038,6 @@ public class RecipeOverride {
                 }
             }
         }
-
-        // Steel Fluid Extraction (to allow automation of Small Steel Gears at LV)
-        removeRecipesByInputs(FLUID_EXTRACTION_RECIPES, OreDictUnifier.get(ingot, Steel));
-        FLUID_EXTRACTION_RECIPES.recipeBuilder().EUt(30).duration(80)
-                .input(ingot, Steel)
-                .fluidOutputs(Steel.getFluid(L))
-                .buildAndRegister();
     }
 
     private static void recipeRemoval() {

--- a/src/main/java/gregicadditions/recipes/categories/circuits/CircuitRecipes.java
+++ b/src/main/java/gregicadditions/recipes/categories/circuits/CircuitRecipes.java
@@ -28,18 +28,6 @@ import static gregtech.common.items.MetaItems.*;
 
 public class CircuitRecipes {
 
-    private static final List<FluidStack> SOLDER_FLUIDS = new ArrayList<>();
-
-    static {
-        for (String fluid : GAConfig.Misc.solderingFluidList) {
-            String[] fluidSplit = fluid.split(":");
-            int amount = GAUtility.setBetweenInclusive(Integer.parseInt(fluidSplit[1]), 1, 64000);
-
-            FluidStack fluidStack = FluidRegistry.getFluidStack(fluidSplit[0], amount);
-            if (fluidStack != null) SOLDER_FLUIDS.add(fluidStack);
-        }
-    }
-
     // Organized by "Group" rather than by voltage
     public static void init() {
 
@@ -89,654 +77,585 @@ public class CircuitRecipes {
 
     private static void electronicCircuits() {
 
-        for (FluidStack fluidStack : SOLDER_FLUIDS) {
+        // Basic Electronic Circuit
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(16)
+                .inputs(RESISTOR.getStackForm(8))
+                .inputs(CAPACITOR.getStackForm(8))
+                .inputs(GOOD_PHENOLIC_BOARD.getStackForm())
+                .inputs(CENTRAL_PROCESSING_UNIT.getStackForm())
+                .input(wireFine, Copper, 4)
+                .outputs(BASIC_ELECTRONIC_CIRCUIT_LV.getStackForm())
+                .buildAndRegister();
 
-            // Basic Electronic Circuit
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(16)
-                    .inputs(RESISTOR.getStackForm(8))
-                    .inputs(CAPACITOR.getStackForm(8))
-                    .inputs(GOOD_PHENOLIC_BOARD.getStackForm())
-                    .inputs(CENTRAL_PROCESSING_UNIT.getStackForm())
-                    .input(wireFine, Copper, 4)
-                    .fluidInputs(fluidStack)
-                    .outputs(BASIC_ELECTRONIC_CIRCUIT_LV.getStackForm())
-                    .buildAndRegister();
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(16)
+                .inputs(SMD_RESISTOR_REFINED.getStackForm(4))
+                .inputs(SMD_CAPACITOR_REFINED.getStackForm(4))
+                .inputs(GOOD_PHENOLIC_BOARD.getStackForm())
+                .inputs(CENTRAL_PROCESSING_UNIT.getStackForm())
+                .input(wireFine, Copper, 4)
+                .outputs(BASIC_ELECTRONIC_CIRCUIT_LV.getStackForm())
+                .buildAndRegister();
 
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(16)
-                    .inputs(SMD_RESISTOR_REFINED.getStackForm(4))
-                    .inputs(SMD_CAPACITOR_REFINED.getStackForm(4))
-                    .inputs(GOOD_PHENOLIC_BOARD.getStackForm())
-                    .inputs(CENTRAL_PROCESSING_UNIT.getStackForm())
-                    .input(wireFine, Copper, 4)
-                    .fluidInputs(fluidStack)
-                    .outputs(BASIC_ELECTRONIC_CIRCUIT_LV.getStackForm())
-                    .buildAndRegister();
+        // Electronic Assembly
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(16)
+                .inputs(BASIC_ELECTRONIC_CIRCUIT_LV.getStackForm(3))
+                .inputs(TRANSISTOR.getStackForm(2))
+                .inputs(RESISTOR.getStackForm(8))
+                .input(plate, Electrum)
+                .outputs(ELECTRONIC_ASSEMBLY.getStackForm())
+                .buildAndRegister();
 
-            // Electronic Assembly
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(16)
-                    .inputs(BASIC_ELECTRONIC_CIRCUIT_LV.getStackForm(3))
-                    .inputs(TRANSISTOR.getStackForm(2))
-                    .inputs(RESISTOR.getStackForm(8))
-                    .input(plate, Electrum)
-                    .fluidInputs(fluidStack)
-                    .outputs(ELECTRONIC_ASSEMBLY.getStackForm())
-                    .buildAndRegister();
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(16)
+                .inputs(BASIC_ELECTRONIC_CIRCUIT_LV.getStackForm(3))
+                .inputs(SMD_TRANSISTOR_REFINED.getStackForm())
+                .inputs(SMD_RESISTOR_REFINED.getStackForm(4))
+                .input(plate, Electrum)
+                .outputs(ELECTRONIC_ASSEMBLY.getStackForm())
+                .buildAndRegister();
 
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(16)
-                    .inputs(BASIC_ELECTRONIC_CIRCUIT_LV.getStackForm(3))
-                    .inputs(SMD_TRANSISTOR_REFINED.getStackForm())
-                    .inputs(SMD_RESISTOR_REFINED.getStackForm(4))
-                    .input(plate, Electrum)
-                    .fluidInputs(fluidStack)
-                    .outputs(ELECTRONIC_ASSEMBLY.getStackForm())
-                    .buildAndRegister();
+        // Electronic Computer
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(16)
+                .inputs(ELECTRONIC_ASSEMBLY.getStackForm(4))
+                .inputs(CAPACITOR.getStackForm(4))
+                .inputs(RESISTOR.getStackForm(4))
+                .inputs(INTEGRATED_LOGIC_CIRCUIT.getStackForm(2))
+                .input(plate, Aluminium, 2)
+                .input(wireGtSingle, AnnealedCopper, 4)
+                .outputs(ELECTRONIC_COMPUTER.getStackForm())
+                .buildAndRegister();
 
-            // Electronic Computer
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(16)
-                    .inputs(ELECTRONIC_ASSEMBLY.getStackForm(4))
-                    .inputs(CAPACITOR.getStackForm(4))
-                    .inputs(RESISTOR.getStackForm(4))
-                    .inputs(INTEGRATED_LOGIC_CIRCUIT.getStackForm(2))
-                    .input(plate, Aluminium, 2)
-                    .input(wireGtSingle, AnnealedCopper, 4)
-                    .fluidInputs(fluidStack)
-                    .outputs(ELECTRONIC_COMPUTER.getStackForm())
-                    .buildAndRegister();
-
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(16)
-                    .inputs(ELECTRONIC_ASSEMBLY.getStackForm(4))
-                    .inputs(SMD_CAPACITOR_REFINED.getStackForm(2))
-                    .inputs(SMD_RESISTOR_REFINED.getStackForm(2))
-                    .inputs(INTEGRATED_LOGIC_CIRCUIT.getStackForm(2))
-                    .input(plate, Aluminium, 2)
-                    .input(wireGtSingle, AnnealedCopper, 4)
-                    .fluidInputs(fluidStack)
-                    .outputs(ELECTRONIC_COMPUTER.getStackForm())
-                    .buildAndRegister();
-        }
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(16)
+                .inputs(ELECTRONIC_ASSEMBLY.getStackForm(4))
+                .inputs(SMD_CAPACITOR_REFINED.getStackForm(2))
+                .inputs(SMD_RESISTOR_REFINED.getStackForm(2))
+                .inputs(INTEGRATED_LOGIC_CIRCUIT.getStackForm(2))
+                .input(plate, Aluminium, 2)
+                .input(wireGtSingle, AnnealedCopper, 4)
+                .outputs(ELECTRONIC_COMPUTER.getStackForm())
+                .buildAndRegister();
     }
 
     private static void refinedCircuits() {
-        for (FluidStack fluidStack : SOLDER_FLUIDS) {
 
-            // Refined Processor
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(60)
-                    .inputs(RESISTOR.getStackForm(8))
-                    .inputs(TRANSISTOR.getStackForm(8))
-                    .inputs(CAPACITOR.getStackForm(8))
-                    .inputs(GOOD_PLASTIC_BOARD.getStackForm())
-                    .inputs(CENTRAL_PROCESSING_UNIT.getStackForm())
-                    .input(wireFine, TinAlloy, 2)
-                    .fluidInputs(fluidStack)
-                    .outputs(REFINED_PROCESSOR.getStackForm(4))
-                    .buildAndRegister();
+        // Refined Processor
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(60)
+                .inputs(RESISTOR.getStackForm(8))
+                .inputs(TRANSISTOR.getStackForm(8))
+                .inputs(CAPACITOR.getStackForm(8))
+                .inputs(GOOD_PLASTIC_BOARD.getStackForm())
+                .inputs(CENTRAL_PROCESSING_UNIT.getStackForm())
+                .input(wireFine, TinAlloy, 2)
+                .outputs(REFINED_PROCESSOR.getStackForm(4))
+                .buildAndRegister();
 
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(60)
-                    .inputs(SMD_RESISTOR_REFINED.getStackForm(4))
-                    .inputs(SMD_TRANSISTOR_REFINED.getStackForm(4))
-                    .inputs(SMD_CAPACITOR_REFINED.getStackForm(4))
-                    .inputs(GOOD_PLASTIC_BOARD.getStackForm())
-                    .inputs(CENTRAL_PROCESSING_UNIT.getStackForm())
-                    .input(wireFine, TinAlloy, 2)
-                    .fluidInputs(fluidStack)
-                    .outputs(REFINED_PROCESSOR.getStackForm(4))
-                    .buildAndRegister();
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(60)
+                .inputs(SMD_RESISTOR_REFINED.getStackForm(4))
+                .inputs(SMD_TRANSISTOR_REFINED.getStackForm(4))
+                .inputs(SMD_CAPACITOR_REFINED.getStackForm(4))
+                .inputs(GOOD_PLASTIC_BOARD.getStackForm())
+                .inputs(CENTRAL_PROCESSING_UNIT.getStackForm())
+                .input(wireFine, TinAlloy, 2)
+                .outputs(REFINED_PROCESSOR.getStackForm(4))
+                .buildAndRegister();
 
-            // SoC Recipe
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(50).EUt(600)
-                    .inputs(GOOD_PLASTIC_BOARD.getStackForm())
-                    .inputs(SYSTEM_ON_CHIP.getStackForm())
-                    .input(wireFine, TinAlloy, 8)
-                    .fluidInputs(fluidStack)
-                    .outputs(REFINED_PROCESSOR.getStackForm(4))
-                    .buildAndRegister();
+        // SoC Recipe
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(50).EUt(600)
+                .inputs(GOOD_PLASTIC_BOARD.getStackForm())
+                .inputs(SYSTEM_ON_CHIP.getStackForm())
+                .input(wireFine, TinAlloy, 8)
+                .outputs(REFINED_PROCESSOR.getStackForm(4))
+                .buildAndRegister();
 
-            // Refined Assembly
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(60)
-                    .inputs(REFINED_PROCESSOR.getStackForm(3))
-                    .inputs(RESISTOR.getStackForm(8))
-                    .inputs(TRANSISTOR.getStackForm(8))
-                    .inputs(CAPACITOR.getStackForm(8))
-                    .inputs(GOOD_PLASTIC_BOARD.getStackForm())
-                    .input(plate, StainlessSteel)
-                    .fluidInputs(fluidStack)
-                    .outputs(REFINED_ASSEMBLY.getStackForm())
-                    .buildAndRegister();
+        // Refined Assembly
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(60)
+                .inputs(REFINED_PROCESSOR.getStackForm(3))
+                .inputs(RESISTOR.getStackForm(8))
+                .inputs(TRANSISTOR.getStackForm(8))
+                .inputs(CAPACITOR.getStackForm(8))
+                .inputs(GOOD_PLASTIC_BOARD.getStackForm())
+                .input(plate, StainlessSteel)
+                .outputs(REFINED_ASSEMBLY.getStackForm())
+                .buildAndRegister();
 
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(60)
-                    .inputs(REFINED_PROCESSOR.getStackForm(3))
-                    .inputs(SMD_RESISTOR_REFINED.getStackForm(2))
-                    .inputs(SMD_TRANSISTOR_REFINED.getStackForm(2))
-                    .inputs(SMD_CAPACITOR_REFINED.getStackForm(2))
-                    .inputs(GOOD_PLASTIC_BOARD.getStackForm())
-                    .input(plate, StainlessSteel)
-                    .fluidInputs(fluidStack)
-                    .outputs(REFINED_ASSEMBLY.getStackForm())
-                    .buildAndRegister();
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(60)
+                .inputs(REFINED_PROCESSOR.getStackForm(3))
+                .inputs(SMD_RESISTOR_REFINED.getStackForm(2))
+                .inputs(SMD_TRANSISTOR_REFINED.getStackForm(2))
+                .inputs(SMD_CAPACITOR_REFINED.getStackForm(2))
+                .inputs(GOOD_PLASTIC_BOARD.getStackForm())
+                .input(plate, StainlessSteel)
+                .outputs(REFINED_ASSEMBLY.getStackForm())
+                .buildAndRegister();
 
-            // Refined Computer
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(90)
-                    .inputs(REFINED_ASSEMBLY.getStackForm(4))
-                    .inputs(RESISTOR.getStackForm(8))
-                    .inputs(TRANSISTOR.getStackForm(8))
-                    .inputs(RANDOM_ACCESS_MEMORY.getStackForm(2))
-                    .inputs(GOOD_PLASTIC_BOARD.getStackForm())
-                    .input(wireGtSingle, MVSuperconductor)
-                    .fluidInputs(fluidStack)
-                    .outputs(REFINED_COMPUTER.getStackForm())
-                    .buildAndRegister();
+        // Refined Computer
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(90)
+                .inputs(REFINED_ASSEMBLY.getStackForm(4))
+                .inputs(RESISTOR.getStackForm(8))
+                .inputs(TRANSISTOR.getStackForm(8))
+                .inputs(RANDOM_ACCESS_MEMORY.getStackForm(2))
+                .inputs(GOOD_PLASTIC_BOARD.getStackForm())
+                .input(wireGtSingle, MVSuperconductor)
+                .outputs(REFINED_COMPUTER.getStackForm())
+                .buildAndRegister();
 
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(90)
-                    .inputs(REFINED_ASSEMBLY.getStackForm(4))
-                    .inputs(SMD_RESISTOR_REFINED.getStackForm(2))
-                    .inputs(SMD_TRANSISTOR_REFINED.getStackForm(2))
-                    .inputs(RANDOM_ACCESS_MEMORY.getStackForm(2))
-                    .inputs(GOOD_PLASTIC_BOARD.getStackForm())
-                    .input(wireGtSingle, MVSuperconductor)
-                    .fluidInputs(fluidStack)
-                    .outputs(REFINED_COMPUTER.getStackForm())
-                    .buildAndRegister();
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(90)
+                .inputs(REFINED_ASSEMBLY.getStackForm(4))
+                .inputs(SMD_RESISTOR_REFINED.getStackForm(2))
+                .inputs(SMD_TRANSISTOR_REFINED.getStackForm(2))
+                .inputs(RANDOM_ACCESS_MEMORY.getStackForm(2))
+                .inputs(GOOD_PLASTIC_BOARD.getStackForm())
+                .input(wireGtSingle, MVSuperconductor)
+                .outputs(REFINED_COMPUTER.getStackForm())
+                .buildAndRegister();
 
-            // Refined Mainframe
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(500).EUt(110)
-                    .inputs(REFINED_COMPUTER.getStackForm(2))
-                    .inputs(RESISTOR.getStackForm(32))
-                    .inputs(TRANSISTOR.getStackForm(16))
-                    .inputs(DIODE.getStackForm(8))
-                    .inputs(RANDOM_ACCESS_MEMORY.getStackForm(4))
-                    .input(frameGt, StainlessSteel, 4)
-                    .fluidInputs(fluidStack)
-                    .outputs(REFINED_MAINFRAME.getStackForm())
-                    .buildAndRegister();
+        // Refined Mainframe
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(500).EUt(110)
+                .inputs(REFINED_COMPUTER.getStackForm(2))
+                .inputs(RESISTOR.getStackForm(32))
+                .inputs(TRANSISTOR.getStackForm(16))
+                .inputs(DIODE.getStackForm(8))
+                .inputs(RANDOM_ACCESS_MEMORY.getStackForm(4))
+                .input(frameGt, StainlessSteel, 4)
+                .outputs(REFINED_MAINFRAME.getStackForm())
+                .buildAndRegister();
 
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(500).EUt(110)
-                    .inputs(REFINED_COMPUTER.getStackForm(2))
-                    .inputs(SMD_RESISTOR_REFINED.getStackForm(16))
-                    .inputs(SMD_TRANSISTOR_REFINED.getStackForm(8))
-                    .inputs(SMD_DIODE_REFINED.getStackForm(4))
-                    .inputs(RANDOM_ACCESS_MEMORY.getStackForm(4))
-                    .input(frameGt, StainlessSteel, 4)
-                    .fluidInputs(fluidStack)
-                    .outputs(REFINED_MAINFRAME.getStackForm())
-                    .buildAndRegister();
-        }
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(500).EUt(110)
+                .inputs(REFINED_COMPUTER.getStackForm(2))
+                .inputs(SMD_RESISTOR_REFINED.getStackForm(16))
+                .inputs(SMD_TRANSISTOR_REFINED.getStackForm(8))
+                .inputs(SMD_DIODE_REFINED.getStackForm(4))
+                .inputs(RANDOM_ACCESS_MEMORY.getStackForm(4))
+                .input(frameGt, StainlessSteel, 4)
+                .outputs(REFINED_MAINFRAME.getStackForm())
+                .buildAndRegister();
     }
 
     private static void microCircuits() {
-        for (FluidStack fluidStack : SOLDER_FLUIDS) {
 
-            // Micro Processor
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(400)
-                    .inputs(SMD_RESISTOR_REFINED.getStackForm(8))
-                    .inputs(SMD_TRANSISTOR_REFINED.getStackForm(8))
-                    .inputs(SMD_CAPACITOR_REFINED.getStackForm(8))
-                    .inputs(ADVANCED_BOARD.getStackForm())
-                    .inputs(CENTRAL_PROCESSING_UNIT.getStackForm(2))
-                    .input(wireFine, RedAlloy, 2)
-                    .fluidInputs(fluidStack)
-                    .outputs(MICRO_PROCESSOR.getStackForm(4))
-                    .buildAndRegister();
+        // Micro Processor
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(400)
+                .inputs(SMD_RESISTOR_REFINED.getStackForm(8))
+                .inputs(SMD_TRANSISTOR_REFINED.getStackForm(8))
+                .inputs(SMD_CAPACITOR_REFINED.getStackForm(8))
+                .inputs(ADVANCED_BOARD.getStackForm())
+                .inputs(CENTRAL_PROCESSING_UNIT.getStackForm(2))
+                .input(wireFine, RedAlloy, 2)
+                .outputs(MICRO_PROCESSOR.getStackForm(4))
+                .buildAndRegister();
 
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(400)
-                    .inputs(SMD_RESISTOR.getStackForm(4))
-                    .inputs(SMD_TRANSISTOR.getStackForm(4))
-                    .inputs(SMD_CAPACITOR.getStackForm(4))
-                    .inputs(ADVANCED_BOARD.getStackForm())
-                    .inputs(CENTRAL_PROCESSING_UNIT.getStackForm(2))
-                    .input(wireFine, RedAlloy, 2)
-                    .fluidInputs(fluidStack)
-                    .outputs(MICRO_PROCESSOR.getStackForm(4))
-                    .buildAndRegister();
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(400)
+                .inputs(SMD_RESISTOR.getStackForm(4))
+                .inputs(SMD_TRANSISTOR.getStackForm(4))
+                .inputs(SMD_CAPACITOR.getStackForm(4))
+                .inputs(ADVANCED_BOARD.getStackForm())
+                .inputs(CENTRAL_PROCESSING_UNIT.getStackForm(2))
+                .input(wireFine, RedAlloy, 2)
+                .outputs(MICRO_PROCESSOR.getStackForm(4))
+                .buildAndRegister();
 
-            // SoC Recipe
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(50).EUt(2400)
-                    .inputs(ADVANCED_BOARD.getStackForm())
-                    .inputs(SYSTEM_ON_CHIP.getStackForm())
-                    .input(wireFine, RedAlloy, 8)
-                    .fluidInputs(fluidStack)
-                    .outputs(MICRO_PROCESSOR.getStackForm(4))
-                    .buildAndRegister();
+        // SoC Recipe
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(50).EUt(2400)
+                .inputs(ADVANCED_BOARD.getStackForm())
+                .inputs(SYSTEM_ON_CHIP.getStackForm())
+                .input(wireFine, RedAlloy, 8)
+                .outputs(MICRO_PROCESSOR.getStackForm(4))
+                .buildAndRegister();
 
-            // Micro Assembly
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(350)
-                    .inputs(MICRO_PROCESSOR.getStackForm(3))
-                    .inputs(SMD_CAPACITOR_REFINED.getStackForm(4))
-                    .inputs(SMD_RESISTOR_REFINED.getStackForm(8))
-                    .inputs(RANDOM_ACCESS_MEMORY.getStackForm(2))
-                    .inputs(ADVANCED_BOARD.getStackForm())
-                    .input(plate, Titanium)
-                    .fluidInputs(fluidStack)
-                    .outputs(PROCESSOR_ASSEMBLY_HV.getStackForm())
-                    .buildAndRegister();
+        // Micro Assembly
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(350)
+                .inputs(MICRO_PROCESSOR.getStackForm(3))
+                .inputs(SMD_CAPACITOR_REFINED.getStackForm(4))
+                .inputs(SMD_RESISTOR_REFINED.getStackForm(8))
+                .inputs(RANDOM_ACCESS_MEMORY.getStackForm(2))
+                .inputs(ADVANCED_BOARD.getStackForm())
+                .input(plate, Titanium)
+                .outputs(PROCESSOR_ASSEMBLY_HV.getStackForm())
+                .buildAndRegister();
 
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(350)
-                    .inputs(MICRO_PROCESSOR.getStackForm(3))
-                    .inputs(SMD_CAPACITOR.getStackForm(2))
-                    .inputs(SMD_RESISTOR.getStackForm(4))
-                    .inputs(RANDOM_ACCESS_MEMORY.getStackForm(2))
-                    .inputs(ADVANCED_BOARD.getStackForm())
-                    .input(plate, Titanium)
-                    .fluidInputs(fluidStack)
-                    .outputs(PROCESSOR_ASSEMBLY_HV.getStackForm())
-                    .buildAndRegister();
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(350)
+                .inputs(MICRO_PROCESSOR.getStackForm(3))
+                .inputs(SMD_CAPACITOR.getStackForm(2))
+                .inputs(SMD_RESISTOR.getStackForm(4))
+                .inputs(RANDOM_ACCESS_MEMORY.getStackForm(2))
+                .inputs(ADVANCED_BOARD.getStackForm())
+                .input(plate, Titanium)
+                .outputs(PROCESSOR_ASSEMBLY_HV.getStackForm())
+                .buildAndRegister();
 
-            // Micro Computer
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(425)
-                    .inputs(PROCESSOR_ASSEMBLY_HV.getStackForm(4))
-                    .inputs(SMD_RESISTOR_REFINED.getStackForm(8))
-                    .inputs(SMD_TRANSISTOR_REFINED.getStackForm(8))
-                    .inputs(RANDOM_ACCESS_MEMORY.getStackForm(8))
-                    .inputs(ADVANCED_BOARD.getStackForm())
-                    .input(wireGtSingle, HVSuperconductor)
-                    .fluidInputs(fluidStack)
-                    .outputs(MICRO_COMPUTER.getStackForm())
-                    .buildAndRegister();
+        // Micro Computer
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(425)
+                .inputs(PROCESSOR_ASSEMBLY_HV.getStackForm(4))
+                .inputs(SMD_RESISTOR_REFINED.getStackForm(8))
+                .inputs(SMD_TRANSISTOR_REFINED.getStackForm(8))
+                .inputs(RANDOM_ACCESS_MEMORY.getStackForm(8))
+                .inputs(ADVANCED_BOARD.getStackForm())
+                .input(wireGtSingle, HVSuperconductor)
+                .outputs(MICRO_COMPUTER.getStackForm())
+                .buildAndRegister();
 
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(425)
-                    .inputs(PROCESSOR_ASSEMBLY_HV.getStackForm(4))
-                    .inputs(SMD_RESISTOR.getStackForm(4))
-                    .inputs(SMD_TRANSISTOR.getStackForm(4))
-                    .inputs(RANDOM_ACCESS_MEMORY.getStackForm(8))
-                    .inputs(ADVANCED_BOARD.getStackForm())
-                    .input(wireGtSingle, HVSuperconductor)
-                    .fluidInputs(fluidStack)
-                    .outputs(MICRO_COMPUTER.getStackForm())
-                    .buildAndRegister();
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(425)
+                .inputs(PROCESSOR_ASSEMBLY_HV.getStackForm(4))
+                .inputs(SMD_RESISTOR.getStackForm(4))
+                .inputs(SMD_TRANSISTOR.getStackForm(4))
+                .inputs(RANDOM_ACCESS_MEMORY.getStackForm(8))
+                .inputs(ADVANCED_BOARD.getStackForm())
+                .input(wireGtSingle, HVSuperconductor)
+                .outputs(MICRO_COMPUTER.getStackForm())
+                .buildAndRegister();
 
-            // Micro Mainframe
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(500).EUt(500)
-                    .inputs(MICRO_COMPUTER.getStackForm(2))
-                    .inputs(SMD_RESISTOR_REFINED.getStackForm(40))
-                    .inputs(SMD_TRANSISTOR_REFINED.getStackForm(20))
-                    .inputs(SMD_DIODE_REFINED.getStackForm(10))
-                    .inputs(RANDOM_ACCESS_MEMORY.getStackForm(8))
-                    .input(frameGt, Titanium, 4)
-                    .fluidInputs(fluidStack)
-                    .outputs(MICRO_MAINFRAME.getStackForm())
-                    .buildAndRegister();
+        // Micro Mainframe
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(500).EUt(500)
+                .inputs(MICRO_COMPUTER.getStackForm(2))
+                .inputs(SMD_RESISTOR_REFINED.getStackForm(40))
+                .inputs(SMD_TRANSISTOR_REFINED.getStackForm(20))
+                .inputs(SMD_DIODE_REFINED.getStackForm(10))
+                .inputs(RANDOM_ACCESS_MEMORY.getStackForm(8))
+                .input(frameGt, Titanium, 4)
+                .outputs(MICRO_MAINFRAME.getStackForm())
+                .buildAndRegister();
 
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(500).EUt(500)
-                    .inputs(MICRO_COMPUTER.getStackForm(2))
-                    .inputs(SMD_RESISTOR.getStackForm(20))
-                    .inputs(SMD_TRANSISTOR.getStackForm(10))
-                    .inputs(SMD_DIODE.getStackForm(5))
-                    .inputs(RANDOM_ACCESS_MEMORY.getStackForm(8))
-                    .input(frameGt, Titanium, 4)
-                    .fluidInputs(fluidStack)
-                    .outputs(MICRO_MAINFRAME.getStackForm())
-                    .buildAndRegister();
-        }
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(500).EUt(500)
+                .inputs(MICRO_COMPUTER.getStackForm(2))
+                .inputs(SMD_RESISTOR.getStackForm(20))
+                .inputs(SMD_TRANSISTOR.getStackForm(10))
+                .inputs(SMD_DIODE.getStackForm(5))
+                .inputs(RANDOM_ACCESS_MEMORY.getStackForm(8))
+                .input(frameGt, Titanium, 4)
+                .outputs(MICRO_MAINFRAME.getStackForm())
+                .buildAndRegister();
     }
 
     private static void nanoCircuits() {
-        for (FluidStack fluidStack : SOLDER_FLUIDS) {
 
-            // Nano Processor
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(2000)
-                    .inputs(SMD_RESISTOR.getStackForm(8))
-                    .inputs(SMD_TRANSISTOR.getStackForm(8))
-                    .inputs(SMD_CAPACITOR.getStackForm(8))
-                    .inputs(EXTREME_BOARD.getStackForm())
-                    .inputs(NANO_CENTRAL_PROCESSING_UNIT.getStackForm(12))
-                    .input(wireFine, Aluminium, 2)
-                    .fluidInputs(fluidStack)
-                    .outputs(NANO_PROCESSOR_HV.getStackForm(4))
-                    .buildAndRegister();
+        // Nano Processor
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(2000)
+                .inputs(SMD_RESISTOR.getStackForm(8))
+                .inputs(SMD_TRANSISTOR.getStackForm(8))
+                .inputs(SMD_CAPACITOR.getStackForm(8))
+                .inputs(EXTREME_BOARD.getStackForm())
+                .inputs(NANO_CENTRAL_PROCESSING_UNIT.getStackForm(12))
+                .input(wireFine, Aluminium, 2)
+                .outputs(NANO_PROCESSOR_HV.getStackForm(4))
+                .buildAndRegister();
 
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(2000)
-                    .outputs(NANO_PROCESSOR_HV.getStackForm(4))
-                    .inputs(SMD_RESISTOR_NANO.getStackForm(4))
-                    .inputs(SMD_TRANSISTOR_NANO.getStackForm(4))
-                    .inputs(SMD_CAPACITOR_NANO.getStackForm(4))
-                    .inputs(EXTREME_BOARD.getStackForm())
-                    .inputs(NANO_CENTRAL_PROCESSING_UNIT.getStackForm(12))
-                    .input(wireFine, Aluminium, 2)
-                    .fluidInputs(fluidStack)
-                    .buildAndRegister();
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(2000)
+                .outputs(NANO_PROCESSOR_HV.getStackForm(4))
+                .inputs(SMD_RESISTOR_NANO.getStackForm(4))
+                .inputs(SMD_TRANSISTOR_NANO.getStackForm(4))
+                .inputs(SMD_CAPACITOR_NANO.getStackForm(4))
+                .inputs(EXTREME_BOARD.getStackForm())
+                .inputs(NANO_CENTRAL_PROCESSING_UNIT.getStackForm(12))
+                .input(wireFine, Aluminium, 2)
+                .buildAndRegister();
 
-            // SoC Recipe
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(50).EUt(9600)
-                    .inputs(EXTREME_BOARD.getStackForm())
-                    .inputs(SYSTEM_ON_CHIP.getStackForm())
-                    .input(wireFine, Aluminium, 8)
-                    .fluidInputs(fluidStack)
-                    .outputs(NANO_PROCESSOR_HV.getStackForm(4))
-                    .buildAndRegister();
+        // SoC Recipe
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(50).EUt(9600)
+                .inputs(EXTREME_BOARD.getStackForm())
+                .inputs(SYSTEM_ON_CHIP.getStackForm())
+                .input(wireFine, Aluminium, 8)
+                .outputs(NANO_PROCESSOR_HV.getStackForm(4))
+                .buildAndRegister();
 
-            // Nano Processor Assembly
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(2000)
-                    .outputs(NANO_PROCESSOR_ASSEMBLY_EV.getStackForm())
-                    .inputs(NANO_PROCESSOR_HV.getStackForm(3))
-                    .inputs(SMD_CAPACITOR.getStackForm(8))
-                    .inputs(SMD_RESISTOR.getStackForm(8))
-                    .inputs(NANO_CENTRAL_PROCESSING_UNIT.getStackForm(2))
-                    .inputs(EXTREME_BOARD.getStackForm()).input(plate, TungstenSteel)
-                    .fluidInputs(fluidStack)
-                    .buildAndRegister();
+        // Nano Processor Assembly
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(2000)
+                .outputs(NANO_PROCESSOR_ASSEMBLY_EV.getStackForm())
+                .inputs(NANO_PROCESSOR_HV.getStackForm(3))
+                .inputs(SMD_CAPACITOR.getStackForm(8))
+                .inputs(SMD_RESISTOR.getStackForm(8))
+                .inputs(NANO_CENTRAL_PROCESSING_UNIT.getStackForm(2))
+                .inputs(EXTREME_BOARD.getStackForm()).input(plate, TungstenSteel)
+                .buildAndRegister();
 
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(2000)
-                    .inputs(NANO_PROCESSOR_HV.getStackForm(3))
-                    .inputs(SMD_CAPACITOR_NANO.getStackForm(4))
-                    .inputs(SMD_RESISTOR_NANO.getStackForm(4))
-                    .inputs(NANO_CENTRAL_PROCESSING_UNIT.getStackForm(2))
-                    .inputs(EXTREME_BOARD.getStackForm()).input(plate, TungstenSteel)
-                    .fluidInputs(fluidStack)
-                    .outputs(NANO_PROCESSOR_ASSEMBLY_EV.getStackForm())
-                    .buildAndRegister();
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(2000)
+                .inputs(NANO_PROCESSOR_HV.getStackForm(3))
+                .inputs(SMD_CAPACITOR_NANO.getStackForm(4))
+                .inputs(SMD_RESISTOR_NANO.getStackForm(4))
+                .inputs(NANO_CENTRAL_PROCESSING_UNIT.getStackForm(2))
+                .inputs(EXTREME_BOARD.getStackForm()).input(plate, TungstenSteel)
+                .outputs(NANO_PROCESSOR_ASSEMBLY_EV.getStackForm())
+                .buildAndRegister();
 
-            // Nano Computer
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(2000)
-                    .inputs(NANO_PROCESSOR_ASSEMBLY_EV.getStackForm(4))
-                    .inputs(SMD_RESISTOR.getStackForm(8))
-                    .inputs(SMD_TRANSISTOR.getStackForm(8))
-                    .inputs(RANDOM_ACCESS_MEMORY.getStackForm(8))
-                    .inputs(EXTREME_BOARD.getStackForm())
-                    .input(wireGtSingle, EVSuperconductor)
-                    .fluidInputs(fluidStack)
-                    .outputs(NANO_COMPUTER.getStackForm())
-                    .buildAndRegister();
+        // Nano Computer
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(2000)
+                .inputs(NANO_PROCESSOR_ASSEMBLY_EV.getStackForm(4))
+                .inputs(SMD_RESISTOR.getStackForm(8))
+                .inputs(SMD_TRANSISTOR.getStackForm(8))
+                .inputs(RANDOM_ACCESS_MEMORY.getStackForm(8))
+                .inputs(EXTREME_BOARD.getStackForm())
+                .input(wireGtSingle, EVSuperconductor)
+                .outputs(NANO_COMPUTER.getStackForm())
+                .buildAndRegister();
 
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(2000)
-                    .outputs(NANO_COMPUTER.getStackForm())
-                    .inputs(NANO_PROCESSOR_ASSEMBLY_EV.getStackForm(4),
-                            SMD_RESISTOR_NANO.getStackForm(4),
-                            SMD_TRANSISTOR_NANO.getStackForm(4),
-                            RANDOM_ACCESS_MEMORY.getStackForm(8),
-                            EXTREME_BOARD.getStackForm())
-                    .input(wireGtSingle, EVSuperconductor)
-                    .fluidInputs(fluidStack)
-                    .buildAndRegister();
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(2000)
+                .outputs(NANO_COMPUTER.getStackForm())
+                .inputs(NANO_PROCESSOR_ASSEMBLY_EV.getStackForm(4))
+                .inputs(SMD_RESISTOR_NANO.getStackForm(4))
+                .inputs(SMD_TRANSISTOR_NANO.getStackForm(4))
+                .inputs(RANDOM_ACCESS_MEMORY.getStackForm(8))
+                .inputs(EXTREME_BOARD.getStackForm())
+                .input(wireGtSingle, EVSuperconductor)
+                .buildAndRegister();
 
-            // Nano Mainframe
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(500).EUt(2000)
-                    .inputs(NANO_COMPUTER.getStackForm(2))
-                    .inputs(SMD_RESISTOR.getStackForm(48))
-                    .inputs(SMD_TRANSISTOR.getStackForm(24))
-                    .inputs(SMD_DIODE.getStackForm(12))
-                    .inputs(RANDOM_ACCESS_MEMORY.getStackForm(12))
-                    .input(frameGt, TungstenSteel, 4)
-                    .fluidInputs(fluidStack)
-                    .outputs(NANO_MAINFRAME.getStackForm())
-                    .buildAndRegister();
+        // Nano Mainframe
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(500).EUt(2000)
+                .inputs(NANO_COMPUTER.getStackForm(2))
+                .inputs(SMD_RESISTOR.getStackForm(48))
+                .inputs(SMD_TRANSISTOR.getStackForm(24))
+                .inputs(SMD_DIODE.getStackForm(12))
+                .inputs(RANDOM_ACCESS_MEMORY.getStackForm(12))
+                .input(frameGt, TungstenSteel, 4)
+                .outputs(NANO_MAINFRAME.getStackForm())
+                .buildAndRegister();
 
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(500).EUt(2000)
-                    .inputs(NANO_COMPUTER.getStackForm(2))
-                    .inputs(SMD_RESISTOR_NANO.getStackForm(24))
-                    .inputs(SMD_TRANSISTOR_NANO.getStackForm(12))
-                    .inputs(SMD_DIODE_NANO.getStackForm(6))
-                    .inputs(RANDOM_ACCESS_MEMORY.getStackForm(12))
-                    .input(frameGt, TungstenSteel, 4)
-                    .fluidInputs(fluidStack)
-                    .outputs(NANO_MAINFRAME.getStackForm())
-                    .buildAndRegister();
-        }
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(500).EUt(2000)
+                .inputs(NANO_COMPUTER.getStackForm(2))
+                .inputs(SMD_RESISTOR_NANO.getStackForm(24))
+                .inputs(SMD_TRANSISTOR_NANO.getStackForm(12))
+                .inputs(SMD_DIODE_NANO.getStackForm(6))
+                .inputs(RANDOM_ACCESS_MEMORY.getStackForm(12))
+                .input(frameGt, TungstenSteel, 4)
+                .outputs(NANO_MAINFRAME.getStackForm())
+                .buildAndRegister();
     }
 
     private static void quantumCircuits() {
-        for (FluidStack fluidStack : SOLDER_FLUIDS) {
 
-            // Quantum Processor
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(3000)
-                    .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm())
-                    .inputs(SMD_TRANSISTOR_NANO.getStackForm(8))
-                    .inputs(SMD_CAPACITOR_NANO.getStackForm(8))
-                    .inputs(ELITE_BOARD.getStackForm())
-                    .inputs(NANO_CENTRAL_PROCESSING_UNIT.getStackForm())
-                    .input(wireFine, Platinum, 2)
-                    .fluidInputs(fluidStack)
-                    .outputs(QUANTUM_PROCESSOR_EV.getStackForm(4))
-                    .buildAndRegister();
+        // Quantum Processor
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(3000)
+                .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm())
+                .inputs(SMD_TRANSISTOR_NANO.getStackForm(8))
+                .inputs(SMD_CAPACITOR_NANO.getStackForm(8))
+                .inputs(ELITE_BOARD.getStackForm())
+                .inputs(NANO_CENTRAL_PROCESSING_UNIT.getStackForm())
+                .input(wireFine, Platinum, 2)
+                .outputs(QUANTUM_PROCESSOR_EV.getStackForm(4))
+                .buildAndRegister();
 
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(3000)
-                    .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm())
-                    .inputs(SMD_TRANSISTOR_QUANTUM.getStackForm(4))
-                    .inputs(SMD_CAPACITOR_QUANTUM.getStackForm(4))
-                    .inputs(ELITE_BOARD.getStackForm())
-                    .inputs(NANO_CENTRAL_PROCESSING_UNIT.getStackForm())
-                    .input(wireFine, Platinum, 2)
-                    .fluidInputs(fluidStack)
-                    .outputs(QUANTUM_PROCESSOR_EV.getStackForm(4))
-                    .buildAndRegister();
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(3000)
+                .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm())
+                .inputs(SMD_TRANSISTOR_QUANTUM.getStackForm(4))
+                .inputs(SMD_CAPACITOR_QUANTUM.getStackForm(4))
+                .inputs(ELITE_BOARD.getStackForm())
+                .inputs(NANO_CENTRAL_PROCESSING_UNIT.getStackForm())
+                .input(wireFine, Platinum, 2)
+                .outputs(QUANTUM_PROCESSOR_EV.getStackForm(4))
+                .buildAndRegister();
 
-            // ASoC Recipe
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(50).EUt(36000)
-                    .inputs(ELITE_BOARD.getStackForm())
-                    .inputs(ADVANCED_SYSTEM_ON_CHIP.getStackForm())
-                    .input(wireFine, Platinum, 8)
-                    .fluidInputs(fluidStack)
-                    .outputs(QUANTUM_PROCESSOR_EV.getStackForm(4))
-                    .buildAndRegister();
+        // ASoC Recipe
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(50).EUt(36000)
+                .inputs(ELITE_BOARD.getStackForm())
+                .inputs(ADVANCED_SYSTEM_ON_CHIP.getStackForm())
+                .input(wireFine, Platinum, 8)
+                .outputs(QUANTUM_PROCESSOR_EV.getStackForm(4))
+                .buildAndRegister();
 
 
-            // Quantum Assembly
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(4000)
-                    .inputs(QUANTUM_PROCESSOR_EV.getStackForm(3))
-                    .inputs(SMD_CAPACITOR_NANO.getStackForm(8))
-                    .inputs(SMD_RESISTOR_NANO.getStackForm(8))
-                    .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm(2))
-                    .inputs(ELITE_BOARD.getStackForm())
-                    .input(plate, Osmium)
-                    .fluidInputs(fluidStack)
-                    .outputs(QUANTUM_ASSEMBLY.getStackForm())
-                    .buildAndRegister();
+        // Quantum Assembly
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(4000)
+                .inputs(QUANTUM_PROCESSOR_EV.getStackForm(3))
+                .inputs(SMD_CAPACITOR_NANO.getStackForm(8))
+                .inputs(SMD_RESISTOR_NANO.getStackForm(8))
+                .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm(2))
+                .inputs(ELITE_BOARD.getStackForm())
+                .input(plate, Osmium)
+                .outputs(QUANTUM_ASSEMBLY.getStackForm())
+                .buildAndRegister();
 
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(4000)
-                    .inputs(QUANTUM_PROCESSOR_EV.getStackForm(3))
-                    .inputs(SMD_CAPACITOR_QUANTUM.getStackForm(4))
-                    .inputs(SMD_RESISTOR_QUANTUM.getStackForm(4))
-                    .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm(2))
-                    .inputs(ELITE_BOARD.getStackForm())
-                    .input(plate, Osmium)
-                    .fluidInputs(fluidStack)
-                    .outputs(QUANTUM_ASSEMBLY.getStackForm())
-                    .buildAndRegister();
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(4000)
+                .inputs(QUANTUM_PROCESSOR_EV.getStackForm(3))
+                .inputs(SMD_CAPACITOR_QUANTUM.getStackForm(4))
+                .inputs(SMD_RESISTOR_QUANTUM.getStackForm(4))
+                .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm(2))
+                .inputs(ELITE_BOARD.getStackForm())
+                .input(plate, Osmium)
+                .outputs(QUANTUM_ASSEMBLY.getStackForm())
+                .buildAndRegister();
 
-            // Quantum Computer
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(6000)
-                    .inputs(QUANTUM_ASSEMBLY.getStackForm(4))
-                    .inputs(SMD_DIODE_NANO.getStackForm(16))
-                    .inputs(QUANTUM_EYE.getStackForm())
-                    .inputs(POWER_INTEGRATED_CIRCUIT.getStackForm(4))
-                    .inputs(ELITE_BOARD.getStackForm())
-                    .input(wireGtSingle, IVSuperconductor, 2)
-                    .fluidInputs(fluidStack)
-                    .outputs(QUANTUM_COMPUTER.getStackForm())
-                    .buildAndRegister();
+        // Quantum Computer
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(6000)
+                .inputs(QUANTUM_ASSEMBLY.getStackForm(4))
+                .inputs(SMD_DIODE_NANO.getStackForm(16))
+                .inputs(QUANTUM_EYE.getStackForm())
+                .inputs(POWER_INTEGRATED_CIRCUIT.getStackForm(4))
+                .inputs(ELITE_BOARD.getStackForm())
+                .input(wireGtSingle, IVSuperconductor, 2)
+                .outputs(QUANTUM_COMPUTER.getStackForm())
+                .buildAndRegister();
 
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(6000)
-                    .inputs(QUANTUM_ASSEMBLY.getStackForm(4))
-                    .inputs(SMD_DIODE_QUANTUM.getStackForm(8))
-                    .inputs(QUANTUM_EYE.getStackForm())
-                    .inputs(POWER_INTEGRATED_CIRCUIT.getStackForm(4))
-                    .inputs(ELITE_BOARD.getStackForm())
-                    .input(wireGtSingle, IVSuperconductor, 2)
-                    .fluidInputs(fluidStack)
-                    .outputs(QUANTUM_COMPUTER.getStackForm())
-                    .buildAndRegister();
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(6000)
+                .inputs(QUANTUM_ASSEMBLY.getStackForm(4))
+                .inputs(SMD_DIODE_QUANTUM.getStackForm(8))
+                .inputs(QUANTUM_EYE.getStackForm())
+                .inputs(POWER_INTEGRATED_CIRCUIT.getStackForm(4))
+                .inputs(ELITE_BOARD.getStackForm())
+                .input(wireGtSingle, IVSuperconductor, 2)
+                .outputs(QUANTUM_COMPUTER.getStackForm())
+                .buildAndRegister();
 
-            // Quantum Mainframe
-            ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(500).EUt(8000)
-                    .inputs(QUANTUM_COMPUTER.getStackForm(2))
-                    .inputs(SMD_RESISTOR_NANO.getStackForm(64))
-                    .inputs(SMD_TRANSISTOR_NANO.getStackForm(56))
-                    .inputs(SMD_CAPACITOR_NANO.getStackForm(56))
-                    .inputs(SMD_DIODE_NANO.getStackForm(32))
-                    .inputs(POWER_INTEGRATED_CIRCUIT.getStackForm(8))
-                    .inputs(QUANTUM_STAR.getStackForm())
-                    .input(frameGt, TungstenSteel, 4)
-                    .input(wireGtSingle, IVSuperconductor, 16)
-                    .fluidInputs(fluidStack)
-                    .outputs(QUANTUM_MAINFRAME.getStackForm())
-                    .buildAndRegister();
+        // Quantum Mainframe
+        ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(500).EUt(8000)
+                .inputs(QUANTUM_COMPUTER.getStackForm(2))
+                .inputs(SMD_RESISTOR_NANO.getStackForm(64))
+                .inputs(SMD_TRANSISTOR_NANO.getStackForm(56))
+                .inputs(SMD_CAPACITOR_NANO.getStackForm(56))
+                .inputs(SMD_DIODE_NANO.getStackForm(32))
+                .inputs(POWER_INTEGRATED_CIRCUIT.getStackForm(8))
+                .inputs(QUANTUM_STAR.getStackForm())
+                .input(frameGt, TungstenSteel, 4)
+                .input(wireGtSingle, IVSuperconductor, 16)
+                .outputs(QUANTUM_MAINFRAME.getStackForm())
+                .buildAndRegister();
 
-            ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(500).EUt(8000)
-                    .inputs(QUANTUM_COMPUTER.getStackForm(2))
-                    .inputs(SMD_RESISTOR_QUANTUM.getStackForm(32))
-                    .inputs(SMD_TRANSISTOR_QUANTUM.getStackForm(28))
-                    .inputs(SMD_CAPACITOR_QUANTUM.getStackForm(28))
-                    .inputs(SMD_DIODE_QUANTUM.getStackForm(16))
-                    .inputs(POWER_INTEGRATED_CIRCUIT.getStackForm(8))
-                    .inputs(QUANTUM_STAR.getStackForm())
-                    .input(frameGt, TungstenSteel, 4)
-                    .input(wireGtSingle, IVSuperconductor, 16)
-                    .fluidInputs(fluidStack)
-                    .outputs(QUANTUM_MAINFRAME.getStackForm())
-                    .buildAndRegister();
-        }
+        ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(500).EUt(8000)
+                .inputs(QUANTUM_COMPUTER.getStackForm(2))
+                .inputs(SMD_RESISTOR_QUANTUM.getStackForm(32))
+                .inputs(SMD_TRANSISTOR_QUANTUM.getStackForm(28))
+                .inputs(SMD_CAPACITOR_QUANTUM.getStackForm(28))
+                .inputs(SMD_DIODE_QUANTUM.getStackForm(16))
+                .inputs(POWER_INTEGRATED_CIRCUIT.getStackForm(8))
+                .inputs(QUANTUM_STAR.getStackForm())
+                .input(frameGt, TungstenSteel, 4)
+                .input(wireGtSingle, IVSuperconductor, 16)
+                .outputs(QUANTUM_MAINFRAME.getStackForm())
+                .buildAndRegister();
     }
 
     private static void crystalCircuits() {
-        for (FluidStack fluidStack : SOLDER_FLUIDS) {
 
-            // Crystal Processor
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(10000)
-                    .inputs(CRYSTAL_CENTRAL_PROCESSING_UNIT.getStackForm())
-                    .inputs(SMD_TRANSISTOR_QUANTUM.getStackForm(16))
-                    .inputs(SMD_CAPACITOR_QUANTUM.getStackForm(8))
-                    .inputs(KAPTON_CIRCUIT_BOARD.getStackForm())
-                    .inputs(NANO_CENTRAL_PROCESSING_UNIT.getStackForm())
-                    .input(wireFine, NiobiumTitanium, 2)
-                    .fluidInputs(fluidStack)
-                    .outputs(CRYSTAL_PROCESSOR.getStackForm(4))
-                    .buildAndRegister();
+        // Crystal Processor
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(10000)
+                .inputs(CRYSTAL_CENTRAL_PROCESSING_UNIT.getStackForm())
+                .inputs(SMD_TRANSISTOR_QUANTUM.getStackForm(16))
+                .inputs(SMD_CAPACITOR_QUANTUM.getStackForm(8))
+                .inputs(KAPTON_CIRCUIT_BOARD.getStackForm())
+                .inputs(NANO_CENTRAL_PROCESSING_UNIT.getStackForm())
+                .input(wireFine, NiobiumTitanium, 2)
+                .outputs(CRYSTAL_PROCESSOR.getStackForm(4))
+                .buildAndRegister();
 
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(10000)
-                    .inputs(CRYSTAL_CENTRAL_PROCESSING_UNIT.getStackForm())
-                    .inputs(SMD_TRANSISTOR_CRYSTAL.getStackForm(8))
-                    .inputs(SMD_CAPACITOR_CRYSTAL.getStackForm(4))
-                    .inputs(KAPTON_CIRCUIT_BOARD.getStackForm())
-                    .inputs(NANO_CENTRAL_PROCESSING_UNIT.getStackForm())
-                    .input(wireFine, NiobiumTitanium, 2)
-                    .fluidInputs(fluidStack)
-                    .outputs(CRYSTAL_PROCESSOR.getStackForm(4))
-                    .buildAndRegister();
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(10000)
+                .inputs(CRYSTAL_CENTRAL_PROCESSING_UNIT.getStackForm())
+                .inputs(SMD_TRANSISTOR_CRYSTAL.getStackForm(8))
+                .inputs(SMD_CAPACITOR_CRYSTAL.getStackForm(4))
+                .inputs(KAPTON_CIRCUIT_BOARD.getStackForm())
+                .inputs(NANO_CENTRAL_PROCESSING_UNIT.getStackForm())
+                .input(wireFine, NiobiumTitanium, 2)
+                .outputs(CRYSTAL_PROCESSOR.getStackForm(4))
+                .buildAndRegister();
 
-            // Crystal SoC Recipe
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(50).EUt(86000)
-                    .inputs(KAPTON_CIRCUIT_BOARD.getStackForm())
-                    .inputs(CRYSTAL_SYSTEM_ON_CHIP.getStackForm())
-                    .input(wireFine, NiobiumTitanium, 8)
-                    .fluidInputs(fluidStack)
-                    .outputs(CRYSTAL_PROCESSOR.getStackForm(4))
-                    .buildAndRegister();
+        // Crystal SoC Recipe
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(50).EUt(86000)
+                .inputs(KAPTON_CIRCUIT_BOARD.getStackForm())
+                .inputs(CRYSTAL_SYSTEM_ON_CHIP.getStackForm())
+                .input(wireFine, NiobiumTitanium, 8)
+                .outputs(CRYSTAL_PROCESSOR.getStackForm(4))
+                .buildAndRegister();
 
-            // Crystal Processor Assembly
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(20000)
-                    .inputs(CRYSTAL_PROCESSOR.getStackForm(3))
-                    .inputs(CENTRAL_PROCESSING_UNIT.getStackForm(64))
-                    .inputs(SMD_RESISTOR_QUANTUM.getStackForm(8))
-                    .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm())
-                    .inputs(KAPTON_CIRCUIT_BOARD.getStackForm())
-                    .input(wireGtSingle, LuVSuperconductor, 4)
-                    .fluidInputs(fluidStack)
-                    .outputs(ENERGY_FLOW_CIRCUIT_LUV.getStackForm())
-                    .buildAndRegister();
+        // Crystal Processor Assembly
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(20000)
+                .inputs(CRYSTAL_PROCESSOR.getStackForm(3))
+                .inputs(CENTRAL_PROCESSING_UNIT.getStackForm(64))
+                .inputs(SMD_RESISTOR_QUANTUM.getStackForm(8))
+                .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm())
+                .inputs(KAPTON_CIRCUIT_BOARD.getStackForm())
+                .input(wireGtSingle, LuVSuperconductor, 4)
+                .outputs(ENERGY_FLOW_CIRCUIT_LUV.getStackForm())
+                .buildAndRegister();
 
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(20000)
-                    .inputs(CRYSTAL_PROCESSOR.getStackForm(3))
-                    .inputs(CENTRAL_PROCESSING_UNIT.getStackForm(64))
-                    .inputs(SMD_RESISTOR_CRYSTAL.getStackForm(4))
-                    .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm())
-                    .inputs(KAPTON_CIRCUIT_BOARD.getStackForm())
-                    .input(wireGtSingle, LuVSuperconductor, 4)
-                    .fluidInputs(fluidStack)
-                    .outputs(ENERGY_FLOW_CIRCUIT_LUV.getStackForm())
-                    .buildAndRegister();
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(20000)
+                .inputs(CRYSTAL_PROCESSOR.getStackForm(3))
+                .inputs(CENTRAL_PROCESSING_UNIT.getStackForm(64))
+                .inputs(SMD_RESISTOR_CRYSTAL.getStackForm(4))
+                .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm())
+                .inputs(KAPTON_CIRCUIT_BOARD.getStackForm())
+                .input(wireGtSingle, LuVSuperconductor, 4)
+                .outputs(ENERGY_FLOW_CIRCUIT_LUV.getStackForm())
+                .buildAndRegister();
 
-            // Crystal Computer
-            ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(300).EUt(30000)
-                    .inputs(ENERGY_FLOW_CIRCUIT_LUV.getStackForm(4))
-                    .inputs(SMD_DIODE_QUANTUM.getStackForm(16))
-                    .inputs(SMD_RESISTOR_QUANTUM.getStackForm(16))
-                    .inputs(QUANTUM_EYE.getStackForm())
-                    .inputs(HIGH_POWER_INTEGRATED_CIRCUIT.getStackForm())
-                    .inputs(KAPTON_CIRCUIT_BOARD.getStackForm())
-                    .input(plate, RhodiumPlatedPalladium, 2)
-                    .input(wireGtSingle, LuVSuperconductor, 16)
-                    .fluidInputs(fluidStack)
-                    .outputs(CRYSTAL_COMPUTER.getStackForm())
-                    .buildAndRegister();
+        // Crystal Computer
+        ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(300).EUt(30000)
+                .inputs(ENERGY_FLOW_CIRCUIT_LUV.getStackForm(4))
+                .inputs(SMD_DIODE_QUANTUM.getStackForm(16))
+                .inputs(SMD_RESISTOR_QUANTUM.getStackForm(16))
+                .inputs(QUANTUM_EYE.getStackForm())
+                .inputs(HIGH_POWER_INTEGRATED_CIRCUIT.getStackForm())
+                .inputs(KAPTON_CIRCUIT_BOARD.getStackForm())
+                .input(plate, RhodiumPlatedPalladium, 2)
+                .input(wireGtSingle, LuVSuperconductor, 16)
+                .outputs(CRYSTAL_COMPUTER.getStackForm())
+                .buildAndRegister();
 
-            ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(300).EUt(30000)
-                    .inputs(ENERGY_FLOW_CIRCUIT_LUV.getStackForm(4))
-                    .inputs(SMD_DIODE_CRYSTAL.getStackForm(8))
-                    .inputs(SMD_RESISTOR_CRYSTAL.getStackForm(8))
-                    .inputs(QUANTUM_EYE.getStackForm())
-                    .inputs(HIGH_POWER_INTEGRATED_CIRCUIT.getStackForm())
-                    .inputs(KAPTON_CIRCUIT_BOARD.getStackForm())
-                    .input(plate, RhodiumPlatedPalladium, 2)
-                    .input(wireGtSingle, LuVSuperconductor, 16)
-                    .fluidInputs(fluidStack)
-                    .outputs(CRYSTAL_COMPUTER.getStackForm())
-                    .buildAndRegister();
+        ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(300).EUt(30000)
+                .inputs(ENERGY_FLOW_CIRCUIT_LUV.getStackForm(4))
+                .inputs(SMD_DIODE_CRYSTAL.getStackForm(8))
+                .inputs(SMD_RESISTOR_CRYSTAL.getStackForm(8))
+                .inputs(QUANTUM_EYE.getStackForm())
+                .inputs(HIGH_POWER_INTEGRATED_CIRCUIT.getStackForm())
+                .inputs(KAPTON_CIRCUIT_BOARD.getStackForm())
+                .input(plate, RhodiumPlatedPalladium, 2)
+                .input(wireGtSingle, LuVSuperconductor, 16)
+                .outputs(CRYSTAL_COMPUTER.getStackForm())
+                .buildAndRegister();
 
-            // Crystal Mainframe
-            ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(500).EUt(30000)
-                    .inputs(CRYSTAL_COMPUTER.getStackForm(2))
-                    .inputs(SMD_RESISTOR_QUANTUM.getStackForm(64))
-                    .inputs(SMD_RESISTOR_QUANTUM.getStackForm(64))
-                    .inputs(SMD_TRANSISTOR_QUANTUM.getStackForm(64))
-                    .inputs(SMD_CAPACITOR_QUANTUM.getStackForm(64))
-                    .inputs(SMD_DIODE_QUANTUM.getStackForm(48))
-                    .inputs(HIGH_POWER_INTEGRATED_CIRCUIT.getStackForm(4))
-                    .inputs(QUANTUM_STAR.getStackForm(4))
-                    .input(frameGt, HSSE, 4)
-                    .input(wireGtSingle, LuVSuperconductor, 32)
-                    .fluidInputs(fluidStack)
-                    .outputs(CRYSTAL_MAINFRAME.getStackForm())
-                    .buildAndRegister();
+        // Crystal Mainframe
+        ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(500).EUt(30000)
+                .inputs(CRYSTAL_COMPUTER.getStackForm(2))
+                .inputs(SMD_RESISTOR_QUANTUM.getStackForm(64))
+                .inputs(SMD_RESISTOR_QUANTUM.getStackForm(64))
+                .inputs(SMD_TRANSISTOR_QUANTUM.getStackForm(64))
+                .inputs(SMD_CAPACITOR_QUANTUM.getStackForm(64))
+                .inputs(SMD_DIODE_QUANTUM.getStackForm(48))
+                .inputs(HIGH_POWER_INTEGRATED_CIRCUIT.getStackForm(4))
+                .inputs(QUANTUM_STAR.getStackForm(4))
+                .input(frameGt, HSSE, 4)
+                .input(wireGtSingle, LuVSuperconductor, 32)
+                .outputs(CRYSTAL_MAINFRAME.getStackForm())
+                .buildAndRegister();
 
-            ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(500).EUt(30000)
-                    .inputs(CRYSTAL_COMPUTER.getStackForm(2))
-                    .inputs(SMD_RESISTOR_CRYSTAL.getStackForm(48))
-                    .inputs(SMD_TRANSISTOR_CRYSTAL.getStackForm(36))
-                    .inputs(SMD_CAPACITOR_CRYSTAL.getStackForm(32))
-                    .inputs(SMD_DIODE_CRYSTAL.getStackForm(24))
-                    .inputs(HIGH_POWER_INTEGRATED_CIRCUIT.getStackForm(4))
-                    .inputs(QUANTUM_STAR.getStackForm(4))
-                    .input(frameGt, HSSE, 4)
-                    .input(wireGtSingle, LuVSuperconductor, 32)
-                    .fluidInputs(fluidStack)
-                    .outputs(CRYSTAL_MAINFRAME.getStackForm())
-                    .buildAndRegister();
-        }
+        ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(500).EUt(30000)
+                .inputs(CRYSTAL_COMPUTER.getStackForm(2))
+                .inputs(SMD_RESISTOR_CRYSTAL.getStackForm(48))
+                .inputs(SMD_TRANSISTOR_CRYSTAL.getStackForm(36))
+                .inputs(SMD_CAPACITOR_CRYSTAL.getStackForm(32))
+                .inputs(SMD_DIODE_CRYSTAL.getStackForm(24))
+                .inputs(HIGH_POWER_INTEGRATED_CIRCUIT.getStackForm(4))
+                .inputs(QUANTUM_STAR.getStackForm(4))
+                .input(frameGt, HSSE, 4)
+                .input(wireGtSingle, LuVSuperconductor, 32)
+                .outputs(CRYSTAL_MAINFRAME.getStackForm())
+                .buildAndRegister();
     }
 
     private static void wetwareCircuits() {
-        for (FluidStack fluidStack : SOLDER_FLUIDS) {
 
-            // Wetware Processor
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(56000)
-                    .inputs(CRYSTAL_SYSTEM_ON_CHIP.getStackForm())
-                    .inputs(SMD_TRANSISTOR_CRYSTAL.getStackForm(16))
-                    .inputs(SMD_CAPACITOR_CRYSTAL.getStackForm(8))
-                    .inputs(CYBER_PROCESSING_UNIT.getStackForm())
-                    .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm())
-                    .input(wireFine, YttriumBariumCuprate, 2)
-                    .fluidInputs(fluidStack)
-                    .outputs(WETWARE_PROCESSOR_LUV.getStackForm())
-                    .buildAndRegister();
+        // Wetware Processor
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(56000)
+                .inputs(CRYSTAL_SYSTEM_ON_CHIP.getStackForm())
+                .inputs(SMD_TRANSISTOR_CRYSTAL.getStackForm(16))
+                .inputs(SMD_CAPACITOR_CRYSTAL.getStackForm(8))
+                .inputs(CYBER_PROCESSING_UNIT.getStackForm())
+                .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm())
+                .input(wireFine, YttriumBariumCuprate, 2)
+                .outputs(WETWARE_PROCESSOR_LUV.getStackForm())
+                .buildAndRegister();
 
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(56000)
-                    .inputs(CRYSTAL_SYSTEM_ON_CHIP.getStackForm())
-                    .inputs(SMD_TRANSISTOR_WETWARE.getStackForm(8))
-                    .inputs(SMD_CAPACITOR_WETWARE.getStackForm(4))
-                    .inputs(CYBER_PROCESSING_UNIT.getStackForm())
-                    .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm())
-                    .input(wireFine, YttriumBariumCuprate, 2)
-                    .fluidInputs(fluidStack)
-                    .outputs(WETWARE_PROCESSOR_LUV.getStackForm())
-                    .buildAndRegister();
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(56000)
+                .inputs(CRYSTAL_SYSTEM_ON_CHIP.getStackForm())
+                .inputs(SMD_TRANSISTOR_WETWARE.getStackForm(8))
+                .inputs(SMD_CAPACITOR_WETWARE.getStackForm(4))
+                .inputs(CYBER_PROCESSING_UNIT.getStackForm())
+                .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm())
+                .input(wireFine, YttriumBariumCuprate, 2)
+                .outputs(WETWARE_PROCESSOR_LUV.getStackForm())
+                .buildAndRegister();
 
-            // ASoC Recipe
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(120000)
-                    .inputs(CYBER_PROCESSING_UNIT.getStackForm())
-                    .inputs(ADVANCED_SYSTEM_ON_CHIP.getStackForm(4))
-                    .input(wireFine, NaquadahAlloy, 8)
-                    .fluidInputs(fluidStack)
-                    .outputs(WETWARE_PROCESSOR_LUV.getStackForm(4))
-                    .buildAndRegister();
-        }
+        // ASoC Recipe
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(120000)
+                .inputs(CYBER_PROCESSING_UNIT.getStackForm())
+                .inputs(ADVANCED_SYSTEM_ON_CHIP.getStackForm(4))
+                .input(wireFine, NaquadahAlloy, 8)
+                .outputs(WETWARE_PROCESSOR_LUV.getStackForm(4))
+                .buildAndRegister();
 
         // Wetware Assembly
         ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(400).EUt(120000)
@@ -822,20 +741,18 @@ public class CircuitRecipes {
     }
 
     private static void biowareCircuits() {
-        for (FluidStack fluidStack : SOLDER_FLUIDS) {
-            FluidStack fluidStackx4 = new FluidStack(fluidStack.getFluid(), Math.min(64000, fluidStack.amount * 4));
 
-            // Bioware Processor
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(240000)
-                    .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm(4))
-                    .inputs(SMD_TRANSISTOR_BIOWARE.getStackForm(8))
-                    .inputs(SMD_CAPACITOR_BIOWARE.getStackForm(4))
-                    .inputs(NEURO_PROCESSOR.getStackForm())
-                    .inputs(HASOC.getStackForm())
-                    .input(wireFine, NaquadahAlloy, 4)
-                    .outputs(BIOWARE_PROCESSOR.getStackForm())
-                    .fluidInputs(fluidStackx4).buildAndRegister();
-        }
+        // Bioware Processor
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(240000)
+                .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm(4))
+                .inputs(SMD_TRANSISTOR_BIOWARE.getStackForm(8))
+                .inputs(SMD_CAPACITOR_BIOWARE.getStackForm(4))
+                .inputs(NEURO_PROCESSOR.getStackForm())
+                .inputs(HASOC.getStackForm())
+                .input(wireFine, NaquadahAlloy, 4)
+                .outputs(BIOWARE_PROCESSOR.getStackForm())
+                .solderMultiplier(4)
+                .buildAndRegister();
 
         // Bioware Assembly
         ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(400).EUt(480000)
@@ -901,21 +818,18 @@ public class CircuitRecipes {
     }
 
     private static void opticalCircuits() {
-        for (FluidStack fluidStack : SOLDER_FLUIDS) {
-            FluidStack fluidStackx4 = new FluidStack(fluidStack.getFluid(), Math.min(64000, fluidStack.amount * 4));
 
-            // Optical Processor
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(960000)
-                    .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm(4))
-                    .inputs(SMD_TRANSISTOR_OPTICAL.getStackForm(8))
-                    .inputs(SMD_CAPACITOR_OPTICAL.getStackForm(4))
-                    .inputs(OPTICAL_PROCESSING_CORE.getStackForm())
-                    .inputs(HASOC.getStackForm())
-                    .input(wireFine, Pikyonium, 4)
-                    .fluidInputs(fluidStackx4)
-                    .outputs(OPTICAL_PROCESSOR.getStackForm())
-                    .buildAndRegister();
-        }
+        // Optical Processor
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(960000)
+                .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm(4))
+                .inputs(SMD_TRANSISTOR_OPTICAL.getStackForm(8))
+                .inputs(SMD_CAPACITOR_OPTICAL.getStackForm(4))
+                .inputs(OPTICAL_PROCESSING_CORE.getStackForm())
+                .inputs(HASOC.getStackForm())
+                .input(wireFine, Pikyonium, 4)
+                .outputs(OPTICAL_PROCESSOR.getStackForm())
+                .solderMultiplier(4)
+                .buildAndRegister();
 
         // Optical Assembly
         ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(400).EUt(960000).qubit(4)
@@ -993,21 +907,18 @@ public class CircuitRecipes {
     }
 
     private static void cosmicCircuits() {
-        for (FluidStack fluidStack : SOLDER_FLUIDS) {
-            FluidStack fluidStackx4 = new FluidStack(fluidStack.getFluid(), Math.min(64000, fluidStack.amount * 4));
 
-            // Cosmic Processor
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(1920000).qubit(16)
-                    .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm(4))
-                    .inputs(SMD_TRANSISTOR_COSMIC.getStackForm(32))
-                    .inputs(SMD_CAPACITOR_COSMIC.getStackForm(16))
-                    .inputs(COSMIC_PROCESSING_CORE.getStackForm())
-                    .inputs(UHASOC.getStackForm())
-                    .input(wireFine, Cinobite, 4)
-                    .fluidInputs(fluidStackx4)
-                    .outputs(COSMIC_PROCESSOR.getStackForm())
-                    .buildAndRegister();
-        }
+        // Cosmic Processor
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(1920000).qubit(16)
+                .inputs(QBIT_CENTRAL_PROCESSING_UNIT.getStackForm(4))
+                .inputs(SMD_TRANSISTOR_COSMIC.getStackForm(32))
+                .inputs(SMD_CAPACITOR_COSMIC.getStackForm(16))
+                .inputs(COSMIC_PROCESSING_CORE.getStackForm())
+                .inputs(UHASOC.getStackForm())
+                .input(wireFine, Cinobite, 4)
+                .outputs(COSMIC_PROCESSOR.getStackForm())
+                .solderMultiplier(4)
+                .buildAndRegister();
 
         // Cosmic Assembly
         ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(400).EUt(3840000).qubit(16)
@@ -1077,21 +988,18 @@ public class CircuitRecipes {
 
 
     private static void supracausalCircuits() {
-        for (FluidStack fluidStack : SOLDER_FLUIDS) {
-            FluidStack fluidStackx4 = new FluidStack(fluidStack.getFluid(), Math.min(64000, fluidStack.amount * 4));
 
-            // Supracausal Processor
-            CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(2097152).qubit(32)
-                    .inputs(UHASOC.getStackForm(16))
-                    .inputs(MANIFOLD_OSCILLATORY_POWER_CELL.getStackForm())
-                    .inputs(MICROWORMHOLE_GENERATOR.getStackForm())
-                    .inputs(SUPRACAUSAL_PROCESSING_CORE.getStackForm())
-                    .input(plate, SuperheavyHAlloy, 4)
-                    .input(wireGtSingle, UHVSuperconductor, 8)
-                    .fluidInputs(fluidStackx4)
-                    .outputs(SUPRACAUSAL_PROCESSOR.getStackForm())
-                    .buildAndRegister();
-        }
+        // Supracausal Processor
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(2097152).qubit(32)
+                .inputs(UHASOC.getStackForm(16))
+                .inputs(MANIFOLD_OSCILLATORY_POWER_CELL.getStackForm())
+                .inputs(MICROWORMHOLE_GENERATOR.getStackForm())
+                .inputs(SUPRACAUSAL_PROCESSING_CORE.getStackForm())
+                .input(plate, SuperheavyHAlloy, 4)
+                .input(wireGtSingle, UHVSuperconductor, 8)
+                .outputs(SUPRACAUSAL_PROCESSOR.getStackForm())
+                .solderMultiplier(4)
+                .buildAndRegister();
 
         // Supracausal Assembly
         ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(200).EUt(8388608).qubit(8)

--- a/src/main/java/gregicadditions/recipes/categories/handlers/OreRecipeHandler.java
+++ b/src/main/java/gregicadditions/recipes/categories/handlers/OreRecipeHandler.java
@@ -43,6 +43,7 @@ public class OreRecipeHandler {
         }
 
         dustImpure.addProcessingHandler(DustMaterial.class, OreRecipeHandler::processDirtyDust);
+        crushed.addProcessingHandler(DustMaterial.class, OreRecipeHandler::processCrushed);
     }
 
 
@@ -285,6 +286,15 @@ public class OreRecipeHandler {
                 .input(dustImpurePrefix, dustMaterial)
                 .fluidInputs(Water.getFluid(100))
                 .output(dust, dustMaterial)
+                .buildAndRegister();
+    }
+
+    public static void processCrushed(OrePrefix dustCrushedPrefix, DustMaterial material) {
+
+        SIMPLE_ORE_WASHER_RECIPES.recipeBuilder()
+                .input(dustCrushedPrefix, material)
+                .fluidInputs(Water.getFluid(100))
+                .output(crushedPurified, material)
                 .buildAndRegister();
     }
 

--- a/src/main/java/gregicadditions/recipes/categories/machines/MachineCraftingRecipes.java
+++ b/src/main/java/gregicadditions/recipes/categories/machines/MachineCraftingRecipes.java
@@ -158,6 +158,7 @@ public class MachineCraftingRecipes {
         OrePrefix plateOrCurved = GAConfig.GT6.addCurvedPlates ? plateCurved : plate;
         // Drums
         ModHandler.addShapedRecipe("wooden_barrel", GATileEntities.WOODEN_DRUM.getStackForm(), "rSs", "PRP", "PRP", 'S', Items.SLIME_BALL, 'P', "plankWood", 'R', new UnificationEntry(stickLong, Iron));
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(30).duration(200).inputs(new ItemStack(Blocks.PLANKS, 4, GTValues.W)).inputs(new ItemStack(Items.SLIME_BALL)).input(stickLong, Iron, 2).outputs(GATileEntities.WOODEN_DRUM.getStackForm()).circuitMeta(1).buildAndRegister();
 
         ModHandler.addShapedRecipe("bronze_drum",          GATileEntities.BRONZE_DRUM.getStackForm(),          " h ", "PRP", "PRP", 'P', new UnificationEntry(plateOrCurved, Bronze),         'R', new UnificationEntry(stickLong, Bronze));
         ModHandler.addShapedRecipe("steel_drum",           GATileEntities.STEEL_DRUM.getStackForm(),           " h ", "PRP", "PRP", 'P', new UnificationEntry(plateOrCurved, Steel),          'R', new UnificationEntry(stickLong, Steel));
@@ -172,6 +173,7 @@ public class MachineCraftingRecipes {
 
         // Crates
         ModHandler.addShapedRecipe("wooden_crate", GATileEntities.WOODEN_CRATE.getStackForm(), "RPR", "PsP", "RPR", 'P', "plankWood", 'R', new UnificationEntry(screw, Iron));
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(30).duration(200).inputs(new ItemStack(Blocks.PLANKS, 4, GTValues.W)).input(screw, Iron, 4).outputs(GATileEntities.WOODEN_CRATE.getStackForm()).circuitMeta(2).buildAndRegister();
 
         ModHandler.addShapedRecipe("bronze_crate",          GATileEntities.BRONZE_CRATE.getStackForm(),          "RPR", "PhP", "RPR", 'P', new UnificationEntry(plateOrCurved, Bronze),         'R', new UnificationEntry(stickLong, Bronze));
         ModHandler.addShapedRecipe("steel_crate",           GATileEntities.STEEL_CRATE.getStackForm(),           "RPR", "PhP", "RPR", 'P', new UnificationEntry(plateOrCurved, Steel),          'R', new UnificationEntry(stickLong, Steel));

--- a/src/main/java/gregicadditions/recipes/categories/machines/MachineCraftingRecipes.java
+++ b/src/main/java/gregicadditions/recipes/categories/machines/MachineCraftingRecipes.java
@@ -164,6 +164,11 @@ public class MachineCraftingRecipes {
         ModHandler.addShapedRecipe("stainless_steel_drum", GATileEntities.STAINLESS_STEEL_DRUM.getStackForm(), " h ", "PRP", "PRP", 'P', new UnificationEntry(plateOrCurved, StainlessSteel), 'R', new UnificationEntry(stickLong, StainlessSteel));
         ModHandler.addShapedRecipe("titanium_drum",        GATileEntities.TITANIUM_DRUM.getStackForm(),        " h ", "PRP", "PRP", 'P', new UnificationEntry(plateOrCurved, Titanium),       'R', new UnificationEntry(stickLong, Titanium));
         ModHandler.addShapedRecipe("tungstensteel_drum",   GATileEntities.TUNGSTENSTEEL_DRUM.getStackForm(),   " h ", "PRP", "PRP", 'P', new UnificationEntry(plateOrCurved, TungstenSteel),  'R', new UnificationEntry(stickLong, TungstenSteel));
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(30).duration(200).input(plateOrCurved, Bronze, 4).input(stickLong, Bronze, 2).outputs(GATileEntities.BRONZE_DRUM.getStackForm()).circuitMeta(1).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(30).duration(200).input(plateOrCurved, Steel, 4).input(stickLong, Steel, 2).outputs(GATileEntities.STEEL_DRUM.getStackForm()).circuitMeta(1).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(30).duration(200).input(plateOrCurved, StainlessSteel, 4).input(stickLong, StainlessSteel, 2).outputs(GATileEntities.STAINLESS_STEEL_DRUM.getStackForm()).circuitMeta(1).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(30).duration(200).input(plateOrCurved, Titanium, 4).input(stickLong, Titanium, 2).outputs(GATileEntities.TITANIUM_DRUM.getStackForm()).circuitMeta(1).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(30).duration(200).input(plateOrCurved, TungstenSteel, 4).input(stickLong, TungstenSteel, 2).outputs(GATileEntities.TUNGSTENSTEEL_DRUM.getStackForm()).circuitMeta(1).buildAndRegister();
 
         // Crates
         ModHandler.addShapedRecipe("wooden_crate", GATileEntities.WOODEN_CRATE.getStackForm(), "RPR", "PsP", "RPR", 'P', "plankWood", 'R', new UnificationEntry(screw, Iron));
@@ -173,6 +178,11 @@ public class MachineCraftingRecipes {
         ModHandler.addShapedRecipe("stainless_steel_crate", GATileEntities.STAINLESS_STEEL_CRATE.getStackForm(), "RPR", "PhP", "RPR", 'P', new UnificationEntry(plateOrCurved, StainlessSteel), 'R', new UnificationEntry(stickLong, StainlessSteel));
         ModHandler.addShapedRecipe("titanium_crate",        GATileEntities.TITANIUM_CRATE.getStackForm(),        "RPR", "PhP", "RPR", 'P', new UnificationEntry(plateOrCurved, Titanium),       'R', new UnificationEntry(stickLong, Titanium));
         ModHandler.addShapedRecipe("tungstensteel_crate",   GATileEntities.TUNGSTENSTEEL_CRATE.getStackForm(),   "RPR", "PhP", "RPR", 'P', new UnificationEntry(plateOrCurved, TungstenSteel),  'R', new UnificationEntry(stickLong, TungstenSteel));
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(30).duration(200).input(plateOrCurved, Bronze, 4).input(stickLong, Bronze, 4).outputs(GATileEntities.BRONZE_CRATE.getStackForm()).circuitMeta(2).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(30).duration(200).input(plateOrCurved, Steel, 4).input(stickLong, Steel, 4).outputs(GATileEntities.STEEL_CRATE.getStackForm()).circuitMeta(2).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(30).duration(200).input(plateOrCurved, StainlessSteel, 4).input(stickLong, StainlessSteel, 4).outputs(GATileEntities.STAINLESS_STEEL_CRATE.getStackForm()).circuitMeta(2).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(30).duration(200).input(plateOrCurved, Titanium, 4).input(stickLong, Titanium, 4).outputs(GATileEntities.TITANIUM_CRATE.getStackForm()).circuitMeta(2).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(30).duration(200).input(plateOrCurved, TungstenSteel, 4).input(stickLong, TungstenSteel, 4).outputs(GATileEntities.TUNGSTENSTEEL_CRATE.getStackForm()).circuitMeta(2).buildAndRegister();
 
         // Energy Converters
         for (final EnergyConverterType type : EnergyConverterType.values()) {

--- a/src/main/java/gregicadditions/recipes/impl/QubitConsumerRecipeBuilder.java
+++ b/src/main/java/gregicadditions/recipes/impl/QubitConsumerRecipeBuilder.java
@@ -1,6 +1,8 @@
 package gregicadditions.recipes.impl;
 
 import com.google.common.collect.ImmutableMap;
+import gregicadditions.GAConfig;
+import gregicadditions.GAUtility;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
@@ -8,7 +10,12 @@ import gregtech.api.util.EnumValidationResult;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.ValidationResult;
 import mcp.MethodsReturnNonnullByDefault;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @see Recipe
@@ -17,7 +24,21 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 @MethodsReturnNonnullByDefault
 public class QubitConsumerRecipeBuilder extends RecipeBuilder<QubitConsumerRecipeBuilder> {
 
+    private static final List<FluidStack> SOLDER_FLUIDS = new ArrayList<>();
+
+    static {
+        for (String fluid : GAConfig.Misc.solderingFluidList) {
+            String[] fluidSplit = fluid.split(":");
+            int amount = GAUtility.setBetweenInclusive(Integer.parseInt(fluidSplit[1]), 1, 64000);
+
+            FluidStack fluidStack = FluidRegistry.getFluidStack(fluidSplit[0], amount);
+            if (fluidStack != null) SOLDER_FLUIDS.add(fluidStack);
+        }
+    }
+
     private int qubit;
+    private int solderMultiplier = 1;
+    private boolean noSolder = false;
 
     public QubitConsumerRecipeBuilder() {
     }
@@ -54,11 +75,34 @@ public class QubitConsumerRecipeBuilder extends RecipeBuilder<QubitConsumerRecip
         return this;
     }
 
+    public QubitConsumerRecipeBuilder solderMultiplier(int multiplier) {
+        this.solderMultiplier = multiplier;
+        return this;
+    }
+
+    public QubitConsumerRecipeBuilder noSolder() {
+        this.noSolder = true;
+        return this;
+    }
+
     public ValidationResult<Recipe> build() {
         return ValidationResult.newResult(finalizeAndValidate(),
                 new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs,
                         ImmutableMap.of("qubitConsume", qubit),
                         duration, EUt, hidden));
+    }
+
+    @Override
+    public void buildAndRegister() {
+        if (!noSolder && fluidInputs.isEmpty()) {
+            for (FluidStack fluidStack : SOLDER_FLUIDS) {
+                recipeMap.addRecipe(this.copy()
+                        .fluidInputs(new FluidStack(fluidStack.getFluid(), Math.min(64000, fluidStack.amount * solderMultiplier)))
+                        .build());
+            }
+        } else {
+            recipeMap.addRecipe(build());
+        }
     }
 
     @Override
@@ -68,6 +112,4 @@ public class QubitConsumerRecipeBuilder extends RecipeBuilder<QubitConsumerRecip
                 .append("qubitConsume", qubit)
                 .toString();
     }
-
-
 }

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -712,6 +712,7 @@ metaitem.tbcco_dust.name=TBCCO Dust
 metaitem.borocarbide_dust.name=Borocarbide Dust
 metaitem.actinium_superhydride.name=Actinium Superhydride
 metaitem.strontium_seaborgium_ruthenate.name=Strontium Seaborgium Ruthenate Superconductor Dust
+metaitem.strontium_superconductor_dust.name=Strontium Superconductor Dust
 metaitem.fullerene_superconductor_dust.name=Fullerene Superconductor Dust
 metaitem.tantalum_carbide.name=Tantalum Carbide
 metaitem.hafnium_carbide.name=Hafnium Carbide


### PR DESCRIPTION
This PR addresses a few issues with recipes, some left over from past PRs, and others older issues:
- Add Assembler Recipes for Drums and Crates including Wood, as they require tools to craft
- Add crushed -> crushedPurified recipes to the Simple Ore Washer
- Fix Schematics decomposing to Stainless Steel, despite being crafted with Steel
- Add a config for harder manual Small Gear recipes instead of forcing it, supersedes #522
- Add 2 <material> -> 1 Small Gear to alloy smelter, for LV Small Gear automation
- Fix Dense Plates, Foils, Double Plates, and Curved Plates using improper recipe durations
- Add Direct Smelting to Iron for Basaltic and Granitic Mineral Sand
- Fix Red Slurry tooltip displaying Silicon despite not containing it
- Add Integrated Circuits to Soldering Alloy, Tin Alloy, and Battery Alloy
- Add Strontium Superconductor Dust en_us localization
- Add Nugget->Ingot and Ingot->Nugget Alloy Smelter Mold recipes
- Rework 1->9 and 3x3 Crafting Table removals, to more easily specify which to disable. As a result, the previous Packer, Unpacker, and Compressor Recipes will always be generated no matter the configs. Additionally, all of these removals are now set to default **false**
- Change Gear hand recipe to use a Wrench instead of a Screwdriver, since it has no screws in the recipe
- Increase the duration of Hot Ingot Vacuum Freezer recipes, to make the upcoming Cryogenic Freezer more viable. This isn't a super significant increase, and the Vacuum Freezer will still easily be faster than a single EBF
- Remove all Small and Tiny Dust Mixer and Crafting Table Alloy recipes since they are basically just JEI clutter. This was at the suggestion of @Shattered2909
- Add mechanism for automatically applying our configured Solder Fluids to Assembly Line and Circuit Assembler recipes. Brief documentation of how to use:
    - Recipes for each solder fluid will automatically be added to your provided recipe
    - You can set `solderMultiplier(int)` to increase the amount of solder used
    - If you call `noSolder()` on the builder, then solder fluids will not be applied even if there are no fluids in the recipe

The release containing this PR will once again need a config file regeneration, which should be noted on release.

Closes #521