### PR TITLE
Add mechanism to add more slots to GTCE RecipeMaps

### DIFF
--- a/src/main/java/gregicadditions/GAEnums.java
+++ b/src/main/java/gregicadditions/GAEnums.java
@@ -1,5 +1,6 @@
 package gregicadditions;
 
+import gregtech.api.recipes.RecipeMap;
 import gregtech.api.unification.Element;
 import gregtech.api.unification.material.MaterialIconType;
 import gregtech.api.unification.material.Materials;
@@ -12,6 +13,8 @@ import gregtech.api.unification.stack.MaterialStack;
 import gregtech.common.MetaFluids;
 import net.minecraftforge.common.util.EnumHelper;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -146,8 +149,31 @@ public class GAEnums {
             OrePrefix.valueOf("orePure" + stoneTypes[i]).addSecondaryMaterial(new MaterialStack(secondaryMaterials[i], OrePrefix.dust.materialAmount));
             PURE_ORES.add(OrePrefix.valueOf("orePure" + stoneTypes[i]));
         }
+    }
 
+    /**
+     * Sets a RecipeMap to have a different number of slots for inputs or outputs.
+     * USE THIS SPARINGLY!
+     *
+     * @param map      The RecipeMap to set the field of.
+     * @param slotType The slot (maxInputs, maxOutputs, etc.) to set.
+     * @param value    The new value of slotType
+     *
+     * @throws Exception If failed.
+     */
+    public static void addSlotsToGTCEMaps(RecipeMap<?> map, String slotType, int value) throws Exception {
 
+        // set public
+        Field field = RecipeMap.class.getDeclaredField(slotType);
+        field.setAccessible(true);
+
+        // set non-final
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
+        // set the value of the parameter
+        field.setInt(map, value);
     }
 
     public static final Predicate<Material> dust = mat -> mat instanceof DustMaterial;

--- a/src/main/java/gregicadditions/GAEnums.java
+++ b/src/main/java/gregicadditions/GAEnums.java
@@ -161,7 +161,11 @@ public class GAEnums {
      *
      * @throws Exception If failed.
      */
-    public static void addSlotsToGTCEMaps(RecipeMap<?> map, String slotType, int value) throws Exception {
+    public static void addSlotsToGTCEMaps(
+            final RecipeMap<?> map,
+            final String       slotType,
+            final int          value)
+            throws Exception {
 
         // set public
         Field field = RecipeMap.class.getDeclaredField(slotType);

--- a/src/main/java/gregicadditions/Gregicality.java
+++ b/src/main/java/gregicadditions/Gregicality.java
@@ -95,6 +95,16 @@ public class Gregicality {
                     "maxOutputs",
                     2
             );
+            GAEnums.addSlotsToGTCEMaps(
+                    RecipeMaps.FERMENTING_RECIPES,
+                    "maxInputs",
+                    1
+            );
+            GAEnums.addSlotsToGTCEMaps(
+                    RecipeMaps.FERMENTING_RECIPES,
+                    "maxOutputs",
+                    1
+            );
         } catch (Exception e) {
             GALog.logger.error("Error setting recipe map fields, {}",
                     e.toString());

--- a/src/main/java/gregicadditions/Gregicality.java
+++ b/src/main/java/gregicadditions/Gregicality.java
@@ -19,6 +19,7 @@ import gregicadditions.theoneprobe.TheOneProbeCompatibility;
 import gregicadditions.utils.GALog;
 import gregicadditions.worldgen.PumpjackHandler;
 import gregtech.api.GTValues;
+import gregtech.api.recipes.RecipeMaps;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.FMLCommonHandler;
@@ -77,9 +78,14 @@ public class Gregicality {
     public static CommonProxy proxy;
 
     public Gregicality() {
-
         GAEnums.preInit();
-
+        try {
+            GAEnums.addSlotsToGTCEMaps(RecipeMaps.DISTILLERY_RECIPES, "maxOutputs", 1);
+            GAEnums.addSlotsToGTCEMaps(RecipeMaps.CHEMICAL_BATH_RECIPES, "maxFluidOutputs", 1);
+            GAEnums.addSlotsToGTCEMaps(RecipeMaps.CHEMICAL_RECIPES, "maxOutputs", 2);
+        } catch (Exception e) {
+            GALog.logger.error("Error setting recipe map fields, {}", e.toString());
+        }
     }
 
     @EventHandler

--- a/src/main/java/gregicadditions/Gregicality.java
+++ b/src/main/java/gregicadditions/Gregicality.java
@@ -80,11 +80,24 @@ public class Gregicality {
     public Gregicality() {
         GAEnums.preInit();
         try {
-            GAEnums.addSlotsToGTCEMaps(RecipeMaps.DISTILLERY_RECIPES, "maxOutputs", 1);
-            GAEnums.addSlotsToGTCEMaps(RecipeMaps.CHEMICAL_BATH_RECIPES, "maxFluidOutputs", 1);
-            GAEnums.addSlotsToGTCEMaps(RecipeMaps.CHEMICAL_RECIPES, "maxOutputs", 2);
+            GAEnums.addSlotsToGTCEMaps(
+                    RecipeMaps.DISTILLERY_RECIPES,
+                    "maxOutputs",
+                    1
+            );
+            GAEnums.addSlotsToGTCEMaps(
+                    RecipeMaps.CHEMICAL_BATH_RECIPES,
+                    "maxFluidOutputs",
+                    1
+            );
+            GAEnums.addSlotsToGTCEMaps(
+                    RecipeMaps.CHEMICAL_RECIPES,
+                    "maxOutputs",
+                    2
+            );
         } catch (Exception e) {
-            GALog.logger.error("Error setting recipe map fields, {}", e.toString());
+            GALog.logger.error("Error setting recipe map fields, {}",
+                    e.toString());
         }
     }
 


### PR DESCRIPTION
This PR adds a (kind of terrible, but functional) way of adding new slots to GTCE RecipeMaps. Currently, I have it adding:
- 1 item output to Distillery
- 1 fluid output to Chemical Bath
- +1 item output to Chemical Reactor

![image](https://user-images.githubusercontent.com/10861407/121821372-1a969380-cc5e-11eb-8567-30dd020335fc.png)
![image](https://user-images.githubusercontent.com/10861407/121821338-09e61d80-cc5e-11eb-9d48-5e98498e2f78.png)
![image](https://user-images.githubusercontent.com/10861407/121821348-110d2b80-cc5e-11eb-87e3-b8740a42cfcd.png)
