### PR TITLE
Update Electric Implosion Compressor

### DIFF
--- a/src/main/java/gregicadditions/recipes/categories/handlers/ElectricImplosionHandler.java
+++ b/src/main/java/gregicadditions/recipes/categories/handlers/ElectricImplosionHandler.java
@@ -54,12 +54,7 @@ public class ElectricImplosionHandler {
         RecipeMaps.IMPLOSION_RECIPES.getRecipeList().forEach(recipe -> {
 
             // Get the explosive type used in this recipe
-            ItemStack explosive;
-            try {
-                explosive = recipe.getProperty(PROPERTY);
-            } catch (IllegalArgumentException e) {
-                explosive = new ItemStack(Blocks.TNT);
-            }
+            ItemStack explosive = (ItemStack) recipe.getRecipePropertyStorage().getRawRecipePropertyValue(PROPERTY);
 
             // Get the input list, converting from CountableIngredient to ItemStack
             AtomicInteger stackCount = new AtomicInteger();

--- a/src/main/java/gregicadditions/recipes/categories/handlers/ElectricImplosionHandler.java
+++ b/src/main/java/gregicadditions/recipes/categories/handlers/ElectricImplosionHandler.java
@@ -65,7 +65,7 @@ public class ElectricImplosionHandler {
                                             .map(Ingredient::getMatchingStacks)
                                             .filter(stack -> stack.length != 0)
                                             .map(array -> array[0])
-                                            .peek(is -> is.setCount(stackCount.get()))
+                                            .peek(is -> is.copy().setCount(stackCount.get()))
                                             .collect(Collectors.toSet()));
 
             // Make sure inputs were properly acquired, and remove explosive


### PR DESCRIPTION
Update the Electric Implosion Compressor after the release of the newest GTCE version, which transitioned the Implosion Compressor over to the new property system.

The try/catch was removed because the explosive was transitioned to an itemstack, and the TNT would be the correct itemstack if a custom explosive was not specified.