### PR TITLE
Fix Recipes for Multi-amp inputs and outputs

### DIFF
--- a/src/main/java/gregicadditions/recipes/helper/HelperMethods.java
+++ b/src/main/java/gregicadditions/recipes/helper/HelperMethods.java
@@ -181,7 +181,8 @@ public class HelperMethods {
     }
 
     private static Object[] prepareRecipe(int tier, Object... recipe) {
-        for (int i = 3; i < recipe.length; i++) {
+        //Don't assume that the recipes are all 3x3. Some recipes are 1x3 shaped, which will fail if the 3x3 assumption is made
+        for (int i = 0; i < recipe.length; i++) {
             if (recipe[i] instanceof GACraftingComponents) {
                 recipe[i] = ((GACraftingComponents) recipe[i]).getIngredient(tier);
             }


### PR DESCRIPTION
Fixes recipes for multi-amp energy input and output hatches. Closes #517 

The error came about because the recipes for the multi-amp hatches are 1x3 shaped, and so only took up one line in the recipe object. Therefore the start at 3 (Which is fine for a normal 3x3 recipe) would leave some CraftingComponents not transformed into their respective items.