### PR TITLE
Adjust 1A transformer recipes

### DIFF
--- a/src/main/java/gregicadditions/recipes/categories/machines/SingleblockCraftingRecipes.java
+++ b/src/main/java/gregicadditions/recipes/categories/machines/SingleblockCraftingRecipes.java
@@ -345,8 +345,8 @@ public class SingleblockCraftingRecipes {
         registerMachineRecipe(GATileEntities.TRANSFORMER_1_AMPS,
                 "KBB", "CM ", "KBB",
                 'M', WORSE_HULL,
-                'C', CABLE_DOUBLE,
-                'B', CABLE_DOUBLE_WORSE,
+                'C', CABLE_SINGLE,
+                'B', CABLE_SINGLE_WORSE,
                 'K', MetaItems.SMALL_COIL);
 
         registerMachineRecipe(GATileEntities.TRANSFORMER_4_AMPS,


### PR DESCRIPTION
Adjusts the 1A transformer recipes to use 1x cables, to prevent recipe conflicts with the higher amperage transformers.

Closes #560 