### PR TITLE
Add caching invalidation on multiblock deform

### DIFF
--- a/src/main/java/gregicadditions/machines/multi/simple/LargeSimpleRecipeMapMultiblockController.java
+++ b/src/main/java/gregicadditions/machines/multi/simple/LargeSimpleRecipeMapMultiblockController.java
@@ -227,6 +227,7 @@ abstract public class LargeSimpleRecipeMapMultiblockController extends GARecipeM
     public void invalidateStructure() {
         super.invalidateStructure();
         this.maxVoltage = 0;
+        ((LargeSimpleMultiblockRecipeLogic) this.recipeMapWorkable).invalidate();
     }
 
 
@@ -324,6 +325,13 @@ abstract public class LargeSimpleRecipeMapMultiblockController extends GARecipeM
         protected List<IItemHandlerModifiable> getInputBuses() {
             RecipeMapMultiblockController controller = (RecipeMapMultiblockController) metaTileEntity;
             return controller.getAbilities(MultiblockAbility.IMPORT_ITEMS);
+        }
+
+        /**
+         * Used to reset cached values after multiblock structure deforms
+         */
+        protected void invalidate() {
+            lastRecipeIndex = 0;
         }
 
         @Override


### PR DESCRIPTION
This aims to address the issue brought up in #571 by adding an invalidation to the `lastRecipeIndex` when the multiblock structure deforms.

Closes #571