### PR TITLE
Add version requirement to block 2.0

### DIFF
--- a/src/main/java/gregicadditions/Gregicality.java
+++ b/src/main/java/gregicadditions/Gregicality.java
@@ -36,7 +36,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import java.io.IOException;
 
 @Mod(modid = Gregicality.MODID, name = Gregicality.NAME, version = Gregicality.VERSION,
-        dependencies = "required-after:gregtech@[1.15.0.721,);" +
+        dependencies = "required-after:gregtech@[1.15.0.721,2.0);" +
                 "after:forestry;" +
                 "after:tconstruct;" +
                 "after:exnihilocreatio;" +


### PR DESCRIPTION
This PR just ensures that when CEu releases, that 0.x releases of Gregicality will display that the mods are incompatible instead of crashing and burning on an error