### PR TITLE
Add dysprosium into the recipe of periodicium

### DIFF
--- a/src/main/java/gregicadditions/recipes/chain/UltimateMaterials.java
+++ b/src/main/java/gregicadditions/recipes/chain/UltimateMaterials.java
@@ -103,6 +103,7 @@ public class UltimateMaterials {
                 .inputs(OreDictUnifier.get(dust, Lutetium))
                 .inputs(OreDictUnifier.get(dust, Scandium))
                 .inputs(OreDictUnifier.get(dust, Yttrium))
+                .inputs(OreDictUnifier.get(dust, Dysprosium))
                 .fluidInputs(Lanthanum.getFluid(144))
                 .fluidInputs(Cerium.getFluid(144))
                 .fluidInputs(Praseodymium.getFluid(144))


### PR DESCRIPTION
This PR fixes a small bug that dysprosium is missing in the recipe of periodicium, but in the formula of periodicium.