### PR TITLE
Reset ForgeGradle to Forge's version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,10 +5,6 @@ buildscript {
     repositories {
         mavenCentral()
         maven {
-            name = "Jitpack"
-            setUrl("https://jitpack.io")
-        }
-        maven {
             name = "Forge"
             setUrl("https://maven.minecraftforge.net")
         }


### PR DESCRIPTION
Due to the recent issues of Jitpack and the fact that ForgeGradle now has a functional Maven, this shifts the maven used to Forge's one. This does cause a warning to appear on literally every build, but that's much better than not being able to build at all.