### PR TITLE
Fix Recipe Conflicts

### DIFF
--- a/src/main/java/gregicadditions/recipes/categories/RecipeOverride.java
+++ b/src/main/java/gregicadditions/recipes/categories/RecipeOverride.java
@@ -167,6 +167,15 @@ public class RecipeOverride {
                 .fluidOutputs(Hydrogen.getFluid(2000))
                 .fluidOutputs(Styrene.getFluid(1000))
                 .buildAndRegister();
+
+        // Raw Rubber (from Isoprene)
+        removeRecipesByInputs(CHEMICAL_RECIPES, Isoprene.getFluid(144), Oxygen.getFluid(2000));
+        CHEMICAL_RECIPES.recipeBuilder().duration(160).EUt(30)
+                .notConsumable(new IntCircuitIngredient(0))
+                .fluidInputs(Isoprene.getFluid(144))
+                .fluidInputs(Oxygen.getFluid(1000))
+                .output(dust, RawRubber, 3)
+                .buildAndRegister();
     }
 
     private static void brewingOverride() {

--- a/src/main/java/gregicadditions/recipes/categories/RecipeOverride.java
+++ b/src/main/java/gregicadditions/recipes/categories/RecipeOverride.java
@@ -176,6 +176,16 @@ public class RecipeOverride {
                 .fluidInputs(Oxygen.getFluid(1000))
                 .output(dust, RawRubber, 3)
                 .buildAndRegister();
+
+        // Methyl Acetate (esterification)
+        removeRecipesByInputs(CHEMICAL_RECIPES, Methanol.getFluid(1000), AceticAcid.getFluid(1000));
+        CHEMICAL_RECIPES.recipeBuilder().duration(240).EUt(30)
+                .notConsumable(new IntCircuitIngredient(1))
+                .fluidInputs(Methanol.getFluid(1000))
+                .fluidInputs(AceticAcid.getFluid(1000))
+                .fluidOutputs(MethylAcetate.getFluid(1000))
+                .fluidOutputs(Water.getFluid(1000))
+                .buildAndRegister();
     }
 
     private static void brewingOverride() {

--- a/src/main/java/gregicadditions/recipes/chain/HNIWChain.java
+++ b/src/main/java/gregicadditions/recipes/chain/HNIWChain.java
@@ -195,7 +195,7 @@ public class HNIWChain {
         //6 CH2O + 4 NH3 -> C6H12N4 + 6 H2O
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(Formaldehyde.getFluid(4000))
-                .fluidOutputs(Ammonia.getFluid(6000))
+                .fluidInputs(Ammonia.getFluid(6000))
                 .outputs(Hexamethylenetetramine.getItemStack(22))
                 .fluidOutputs(Water.getFluid(6000))
                 .EUt(480)


### PR DESCRIPTION
This PR fixes a recipe conflict involving isoprene and oxygen. Isoprene and oxygen in a chemical reactor will currently make raw rubber pulp when attempting to produce Citral instead, preventing progression when working on Bioware circuits.

It also fixes an incorrect recipe for Hexamethylenetetramine where Ammonia was set as an output instead of an input, which created a conflict with any recipe using Formaldehyde as an input as a result. This is also fixed.